### PR TITLE
Add Book repository and entity

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/model/Book.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/model/Book.java
@@ -1,0 +1,30 @@
+package com.mohammadnizam.lms.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "books")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id")
+    private Integer bookId;
+
+    private String isbn;
+    private String title;
+    private String author;
+    private String category;
+
+    @Column(name = "publication_year")
+    private Integer publicationYear;
+
+    @Column(name = "copies_available")
+    private Integer copiesAvailable;
+
+    @Enumerated(EnumType.STRING)
+    private BookStatus status;
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/model/BookStatus.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/model/BookStatus.java
@@ -1,0 +1,7 @@
+package com.mohammadnizam.lms.model;
+
+public enum BookStatus {
+    AVAILABLE,
+    BORROWED,
+    RESERVED
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BookRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BookRepository.java
@@ -1,0 +1,11 @@
+package com.mohammadnizam.lms.repository;
+
+import com.mohammadnizam.lms.model.Book;
+import com.mohammadnizam.lms.model.BookStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookRepository extends JpaRepository<Book, Integer> {
+    List<Book> findByStatusOrCategory(BookStatus status, String category);
+}


### PR DESCRIPTION
## Summary
- add `Book` and `BookStatus` JPA entities
- introduce `BookRepository` with a custom finder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6879b83a0e6c833092f21c1c6ae09da8