### PR TITLE
Add REST controller for books

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BookController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BookController.java
@@ -1,0 +1,49 @@
+package com.mohammadnizam.lms.controller;
+
+import com.mohammadnizam.lms.model.Book;
+import com.mohammadnizam.lms.repository.BookRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/books")
+public class BookController {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @GetMapping
+    public List<Book> getAllBooks() {
+        return bookRepository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Book getBookById(@PathVariable Integer id) {
+        Optional<Book> book = bookRepository.findById(id);
+        return book.orElse(null);
+    }
+
+    @GetMapping("/available")
+    public List<Book> getAvailableBooks() {
+        return bookRepository.findByStatus("AVAILABLE");
+    }
+
+    @PostMapping
+    public Book createBook(@RequestBody Book book) {
+        return bookRepository.save(book);
+    }
+
+    @PutMapping("/{id}")
+    public Book updateBook(@PathVariable Integer id, @RequestBody Book book) {
+        book.setBookId(id);
+        return bookRepository.save(book);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteBook(@PathVariable Integer id) {
+        bookRepository.deleteById(id);
+    }
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BookRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BookRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Integer> {
     List<Book> findByStatusOrCategory(String status, String category);
+    List<Book> findByStatus(String status);
 }


### PR DESCRIPTION
## Summary
- add BookController for CRUD operations
- extend BookRepository with `findByStatus` for listing available books

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6879bd8844c08330a6d70d1b262a528a