### PR TITLE
Add repository and controller tests

### DIFF
--- a/lms-backend/pom.xml
+++ b/lms-backend/pom.xml
@@ -78,6 +78,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- H2 Database for tests -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
@@ -1,0 +1,43 @@
+package com.mohammadnizam.lms.controller;
+
+import com.mohammadnizam.lms.model.User;
+import com.mohammadnizam.lms.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void getAllUsers_returnsList() throws Exception {
+        User user = new User();
+        user.setId(1);
+        user.setUsername("john");
+        user.setPassword("pass");
+        user.setRole("USER");
+        given(userRepository.findAll()).willReturn(List.of(user));
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].username").value("john"));
+    }
+}

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/repository/UserRepositoryTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/repository/UserRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.mohammadnizam.lms.repository;
+
+import com.mohammadnizam.lms.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findByUsername_returnsUser() {
+        User user = new User();
+        user.setUsername("johndoe");
+        user.setPassword("pass");
+        user.setRole("USER");
+        user = userRepository.save(user);
+
+        User found = userRepository.findByUsername("johndoe");
+        assertThat(found).isNotNull();
+        assertThat(found.getId()).isEqualTo(user.getId());
+        assertThat(found.getUsername()).isEqualTo("johndoe");
+    }
+}

--- a/lms-backend/src/test/resources/application.properties
+++ b/lms-backend/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add H2 dependency for testing
- provide H2 properties for test profile
- test UserRepository with DataJpaTest
- test UserController GET endpoint with MockMvc

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6879c0e68e788330b890d1c3a6fe9ea4