### PR TITLE
Fix JWT util for jjwt 0.12

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/security/JwtUtil.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/security/JwtUtil.java
@@ -45,7 +45,7 @@ public class JwtUtil {
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_MS))
-                .signWith(SignatureAlgorithm.HS256, getSignInKey())
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
@@ -57,6 +57,7 @@ public class JwtUtil {
     private Claims extractAllClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(getSignInKey())
+                .build()
                 .parseClaimsJws(token)
                 .getBody();
     }


### PR DESCRIPTION
## Summary
- update JwtUtil to use new signWith(Key, SignatureAlgorithm)
- use parser builder when extracting claims

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6879ebf8571c8330ba72344456f73bc0