### PR TITLE
Add createdAt field to User entity

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/model/User.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/model/User.java
@@ -2,6 +2,7 @@ package com.mohammadnizam.lms.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
@@ -11,9 +12,13 @@ import lombok.*;
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Integer id;
 
     private String username;
     private String password;
     private String role;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 }

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/BorrowRecordControllerIntegrationTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/BorrowRecordControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -54,6 +55,7 @@ class BorrowRecordControllerIntegrationTest {
         user.setUsername("member1");
         user.setPassword("pass");
         user.setRole("MEMBER");
+        user.setCreatedAt(LocalDateTime.now());
         user = userRepository.save(user);
 
         Member member = new Member();

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,6 +34,7 @@ class UserControllerTest {
         user.setUsername("john");
         user.setPassword("pass");
         user.setRole("USER");
+        user.setCreatedAt(LocalDateTime.now());
         given(userRepository.findAll()).willReturn(List.of(user));
 
         mockMvc.perform(get("/api/users"))

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/repository/UserRepositoryTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/repository/UserRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.time.LocalDateTime;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -21,6 +22,7 @@ class UserRepositoryTest {
         user.setUsername("johndoe");
         user.setPassword("pass");
         user.setRole("USER");
+        user.setCreatedAt(LocalDateTime.now());
         user = userRepository.save(user);
 
         User found = userRepository.findByUsername("johndoe");


### PR DESCRIPTION
## Summary
- map `created_at` column in `User` entity
- update tests to populate the new timestamp

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6879ec01f2f08330a9122e8bc219d5a2