### PR TITLE
Replace MockBean with mock config

### DIFF
--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
@@ -6,7 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,13 +21,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(UserControllerTest.MockConfig.class)
 class UserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Autowired
     private UserRepository userRepository;
+
+    @TestConfiguration
+    static class MockConfig {
+        @Bean
+        UserRepository userRepository() {
+            return Mockito.mock(UserRepository.class);
+        }
+    }
 
     @Test
     void getAllUsers_returnsList() throws Exception {


### PR DESCRIPTION
## Summary
- configure UserRepository mock without using `@MockBean`
- keep controller test using mocked repository

## Testing
- `./mvnw test` *(fails: `Network is unreachable` while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879ec0810c083309e8d88e20c53ad44