### PR TITLE
Add DTO responses and update controllers

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
@@ -1,8 +1,11 @@
 package com.mohammadnizam.lms.controller;
 
+import com.mohammadnizam.lms.dto.MemberDto;
 import com.mohammadnizam.lms.model.Member;
 import com.mohammadnizam.lms.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,23 +18,38 @@ public class MemberController {
     private MemberRepository memberRepository;
 
     @GetMapping
-    public List<Member> getAllMembers() {
-        return memberRepository.findAll();
+    public ResponseEntity<List<MemberDto>> getAllMembers() {
+        List<MemberDto> list = memberRepository.findAll()
+                .stream()
+                .map(MemberDto::fromEntity)
+                .toList();
+        return ResponseEntity.ok(list);
     }
 
     @PostMapping
-    public Member createMember(@RequestBody Member member) {
-        return memberRepository.save(member);
+    public ResponseEntity<MemberDto> createMember(@RequestBody Member member) {
+        Member saved = memberRepository.save(member);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(MemberDto.fromEntity(saved));
     }
 
     @PutMapping("/{id}")
-    public Member updateMember(@PathVariable Integer id, @RequestBody Member member) {
+    public ResponseEntity<MemberDto> updateMember(@PathVariable Integer id,
+                                                  @RequestBody Member member) {
+        if (!memberRepository.existsById(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
         member.setMemberId(id);
-        return memberRepository.save(member);
+        Member updated = memberRepository.save(member);
+        return ResponseEntity.ok(MemberDto.fromEntity(updated));
     }
 
     @DeleteMapping("/{id}")
-    public void deleteMember(@PathVariable Integer id) {
+    public ResponseEntity<Void> deleteMember(@PathVariable Integer id) {
+        if (!memberRepository.existsById(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
         memberRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/UserController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.mohammadnizam.lms.controller;
 
+import com.mohammadnizam.lms.dto.UserDto;
 import com.mohammadnizam.lms.model.User;
 import com.mohammadnizam.lms.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,7 +17,11 @@ public class UserController {
     private UserRepository userRepository;
 
     @GetMapping
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public ResponseEntity<List<UserDto>> getAllUsers() {
+        List<UserDto> list = userRepository.findAll()
+                .stream()
+                .map(UserDto::fromEntity)
+                .toList();
+        return ResponseEntity.ok(list);
     }
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BookDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BookDto.java
@@ -1,0 +1,36 @@
+package com.mohammadnizam.lms.dto;
+
+import com.mohammadnizam.lms.model.Book;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookDto {
+    private Integer bookId;
+    private String isbn;
+    private String title;
+    private String author;
+    private String category;
+    private Integer publicationYear;
+    private Integer copiesAvailable;
+    private String status;
+
+    public static BookDto fromEntity(Book book) {
+        if (book == null) {
+            return null;
+        }
+        BookDto dto = new BookDto();
+        dto.setBookId(book.getBookId());
+        dto.setIsbn(book.getIsbn());
+        dto.setTitle(book.getTitle());
+        dto.setAuthor(book.getAuthor());
+        dto.setCategory(book.getCategory());
+        dto.setPublicationYear(book.getPublicationYear());
+        dto.setCopiesAvailable(book.getCopiesAvailable());
+        dto.setStatus(book.getStatus());
+        return dto;
+    }
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
@@ -1,0 +1,41 @@
+package com.mohammadnizam.lms.dto;
+
+import com.mohammadnizam.lms.model.BorrowRecord;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BorrowRecordDto {
+    private Integer recordId;
+    private Integer memberId;
+    private Integer bookId;
+    private LocalDate borrowDate;
+    private LocalDate dueDate;
+    private LocalDate returnDate;
+    private BigDecimal fine;
+
+    public static BorrowRecordDto fromEntity(BorrowRecord record) {
+        if (record == null) {
+            return null;
+        }
+        BorrowRecordDto dto = new BorrowRecordDto();
+        dto.setRecordId(record.getRecordId());
+        if (record.getMember() != null) {
+            dto.setMemberId(record.getMember().getMemberId());
+        }
+        if (record.getBook() != null) {
+            dto.setBookId(record.getBook().getBookId());
+        }
+        dto.setBorrowDate(record.getBorrowDate());
+        dto.setDueDate(record.getDueDate());
+        dto.setReturnDate(record.getReturnDate());
+        dto.setFine(record.getFine());
+        return dto;
+    }
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/MemberDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/MemberDto.java
@@ -1,0 +1,38 @@
+package com.mohammadnizam.lms.dto;
+
+import com.mohammadnizam.lms.model.Member;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberDto {
+    private Integer memberId;
+    private String fullName;
+    private String contactInfo;
+    private String address;
+    private LocalDate membershipStart;
+    private LocalDate membershipEnd;
+    private Integer userId;
+
+    public static MemberDto fromEntity(Member member) {
+        if (member == null) {
+            return null;
+        }
+        MemberDto dto = new MemberDto();
+        dto.setMemberId(member.getMemberId());
+        dto.setFullName(member.getFullName());
+        dto.setContactInfo(member.getContactInfo());
+        dto.setAddress(member.getAddress());
+        dto.setMembershipStart(member.getMembershipStart());
+        dto.setMembershipEnd(member.getMembershipEnd());
+        if (member.getUser() != null) {
+            dto.setUserId(member.getUser().getId());
+        }
+        return dto;
+    }
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/UserDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/UserDto.java
@@ -1,0 +1,26 @@
+package com.mohammadnizam.lms.dto;
+
+import com.mohammadnizam.lms.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDto {
+    private Integer id;
+    private String username;
+    private String role;
+
+    public static UserDto fromEntity(User user) {
+        if (user == null) {
+            return null;
+        }
+        UserDto dto = new UserDto();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setRole(user.getRole());
+        return dto;
+    }
+}

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/BorrowRecordControllerIntegrationTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/BorrowRecordControllerIntegrationTest.java
@@ -90,8 +90,7 @@ class BorrowRecordControllerIntegrationTest {
                 .param("memberId", member.getMemberId().toString())
                 .param("bookId", book.getBookId().toString())
                 .header("Authorization", auth))
-                .andExpect(status().isOk())
-                .andExpect(content().string(""));
+                .andExpect(status().isBadRequest());
 
         assertThat(borrowRecordRepository.count()).isZero();
         Book updated = bookRepository.findById(book.getBookId()).orElseThrow();


### PR DESCRIPTION
## Summary
- provide DTO objects for main entities
- update controllers to return `ResponseEntity` with DTOs
- adapt integration tests to new HTTP status expectations

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6879ec061a7c8330bc51ed8868ffb761