### PR TITLE
Fix test enums for BookStatus and Role

### DIFF
--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/BorrowRecordControllerIntegrationTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/BorrowRecordControllerIntegrationTest.java
@@ -4,6 +4,8 @@ import com.mohammadnizam.lms.model.Book;
 import com.mohammadnizam.lms.model.BorrowRecord;
 import com.mohammadnizam.lms.model.Member;
 import com.mohammadnizam.lms.model.User;
+import com.mohammadnizam.lms.model.Role;
+import com.mohammadnizam.lms.model.BookStatus;
 import com.mohammadnizam.lms.repository.BookRepository;
 import com.mohammadnizam.lms.repository.BorrowRecordRepository;
 import com.mohammadnizam.lms.repository.MemberRepository;
@@ -54,7 +56,7 @@ class BorrowRecordControllerIntegrationTest {
         User user = new User();
         user.setUsername("member1");
         user.setPassword("pass");
-        user.setRole("MEMBER");
+        user.setRole(Role.MEMBER);
         user.setCreatedAt(LocalDateTime.now());
         user = userRepository.save(user);
 
@@ -85,7 +87,7 @@ class BorrowRecordControllerIntegrationTest {
         book.setCategory("Fiction");
         book.setPublicationYear(2023);
         book.setCopiesAvailable(0);
-        book.setStatus("BORROWED");
+        book.setStatus(BookStatus.BORROWED);
         book = bookRepository.save(book);
 
         mockMvc.perform(post("/api/borrow-records/borrow")
@@ -111,7 +113,7 @@ class BorrowRecordControllerIntegrationTest {
         book.setCategory("Fiction");
         book.setPublicationYear(2023);
         book.setCopiesAvailable(0);
-        book.setStatus("BORROWED");
+        book.setStatus(BookStatus.BORROWED);
         book = bookRepository.save(book);
 
         BorrowRecord record = new BorrowRecord();
@@ -132,6 +134,6 @@ class BorrowRecordControllerIntegrationTest {
 
         Book returnedBook = bookRepository.findById(book.getBookId()).orElseThrow();
         assertThat(returnedBook.getCopiesAvailable()).isEqualTo(1);
-        assertThat(returnedBook.getStatus()).isEqualTo("AVAILABLE");
+        assertThat(returnedBook.getStatus()).isEqualTo(BookStatus.AVAILABLE);
     }
 }

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.mohammadnizam.lms.controller;
 
 import com.mohammadnizam.lms.model.User;
+import com.mohammadnizam.lms.model.Role;
 import com.mohammadnizam.lms.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +46,7 @@ class UserControllerTest {
         user.setId(1);
         user.setUsername("john");
         user.setPassword("pass");
-        user.setRole("USER");
+        user.setRole(Role.MEMBER);
         user.setCreatedAt(LocalDateTime.now());
         given(userRepository.findAll()).willReturn(List.of(user));
 

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/repository/UserRepositoryTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/repository/UserRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.mohammadnizam.lms.repository;
 
 import com.mohammadnizam.lms.model.User;
+import com.mohammadnizam.lms.model.Role;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -21,7 +22,7 @@ class UserRepositoryTest {
         User user = new User();
         user.setUsername("johndoe");
         user.setPassword("pass");
-        user.setRole("USER");
+        user.setRole(Role.MEMBER);
         user.setCreatedAt(LocalDateTime.now());
         user = userRepository.save(user);
 


### PR DESCRIPTION
## Summary
- fix integration tests to use `BookStatus` enum
- fix controller and repository tests to use `Role` enum

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6879f767edc08330885cb24b3088eaaf