### PR TITLE
Add registration endpoint

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
@@ -9,8 +9,6 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -48,7 +46,7 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return NoOpPasswordEncoder.getInstance();
+        return new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder();
     }
 
     @Bean

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/AuthController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/AuthController.java
@@ -1,12 +1,18 @@
 package com.mohammadnizam.lms.controller.auth;
 
 import com.mohammadnizam.lms.security.JwtUtil;
+import com.mohammadnizam.lms.model.Member;
+import com.mohammadnizam.lms.model.Role;
+import com.mohammadnizam.lms.model.User;
+import com.mohammadnizam.lms.repository.MemberRepository;
+import com.mohammadnizam.lms.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,6 +28,15 @@ public class AuthController {
     @Autowired
     private JwtUtil jwtUtil;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @PostMapping("/login")
     public AuthResponse login(@RequestBody AuthRequest request) throws AuthenticationException {
         UsernamePasswordAuthenticationToken authToken =
@@ -29,6 +44,27 @@ public class AuthController {
         authenticationManager.authenticate(authToken);
         UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
         String token = jwtUtil.generateToken(userDetails.getUsername());
+        return new AuthResponse(token);
+    }
+
+    @PostMapping("/register")
+    public AuthResponse register(@RequestBody RegisterRequest request) {
+        User user = new User();
+        user.setUsername(request.getUsername());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setRole(Role.MEMBER);
+        user = userRepository.save(user);
+
+        Member member = new Member();
+        member.setFullName(request.getFullName());
+        member.setContactInfo(request.getContactInfo());
+        member.setAddress(request.getAddress());
+        member.setMembershipStart(request.getMembershipStart());
+        member.setMembershipEnd(request.getMembershipEnd());
+        member.setUser(user);
+        memberRepository.save(member);
+
+        String token = jwtUtil.generateToken(user.getUsername());
         return new AuthResponse(token);
     }
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/RegisterRequest.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/RegisterRequest.java
@@ -1,0 +1,72 @@
+package com.mohammadnizam.lms.controller.auth;
+
+import java.time.LocalDate;
+
+public class RegisterRequest {
+    private String username;
+    private String password;
+    private String fullName;
+    private String contactInfo;
+    private String address;
+    private LocalDate membershipStart;
+    private LocalDate membershipEnd;
+
+    public RegisterRequest() {
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getContactInfo() {
+        return contactInfo;
+    }
+
+    public void setContactInfo(String contactInfo) {
+        this.contactInfo = contactInfo;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public LocalDate getMembershipStart() {
+        return membershipStart;
+    }
+
+    public void setMembershipStart(LocalDate membershipStart) {
+        this.membershipStart = membershipStart;
+    }
+
+    public LocalDate getMembershipEnd() {
+        return membershipEnd;
+    }
+
+    public void setMembershipEnd(LocalDate membershipEnd) {
+        this.membershipEnd = membershipEnd;
+    }
+}


### PR DESCRIPTION
## Summary
- implement user registration in `AuthController`
- encode passwords with BCrypt
- expose a DTO for registration request
- update security configuration to use BCrypt

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687af1c5ac40833095af13953fc9525e