### PR TITLE
Use bcrypt hashes for sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,19 @@ Entities include `users`, `books`, `members`, `borrow_transactions` and `reserva
 
 ## Setup
 1. Create the database `lms_db` and run `sql/create_tables.sql`.
-2. Start the backend:
+2. (Optional) Seed sample data with hashed passwords by executing `sql/insert_sample_data.sql`. Default logins include `admin/admin123` for an admin user.
+3. Start the backend:
    ```bash
    cd lms-backend
    ./mvnw spring-boot:run
    ```
-3. Start the frontend:
+4. Start the frontend:
    ```bash
    cd lms-frontend
    npm install
    npm run dev
    ```
-4. Open `http://localhost:5173` in a browser.
+5. Open `http://localhost:5173` in a browser.
 
 ## Tests
 Backend unit tests can be executed with:

--- a/sql/insert_sample_data.sql
+++ b/sql/insert_sample_data.sql
@@ -1,9 +1,9 @@
 -- Sample data for 'users' table
 INSERT INTO users (username, password, role) VALUES
-('admin', 'admin123', 'ADMIN'),
-('alice', 'alice123', 'MEMBER'),
-('bob', 'bob123', 'MEMBER'),
-('charlie', 'charlie123', 'MEMBER');
+('admin', '$2b$12$D87ncK5xdIBLlfOJEDUSZeaunRDd1Dj1nJ8xqBEunO1RmIiij.N.O', 'ADMIN'),
+('alice', '$2b$12$jWyxMTgy1wpRc8pGLgLp3uXZclfLVKvU5LKuWKp82EYPfKjOpAV/m', 'MEMBER'),
+('bob', '$2b$12$bFhAvB9RVb26prdkU8StsuCixSPZj13MM4xD2egc3C7/1S7oZmeJu', 'MEMBER'),
+('charlie', '$2b$12$2Y93II1QMvReyQWpN.nJlueKhTdABX7nz6D.mtywUCtNY7S9GrMke', 'MEMBER');
 
 -- Sample data for 'members' table
 INSERT INTO members (user_id, full_name, address, contact_info, membership_start, membership_end) VALUES


### PR DESCRIPTION
## Summary
- mention running `insert_sample_data.sql` in README
- store bcrypt hashed passwords in sample data

## Testing
- `mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687af306f1bc833093389b84c9d36f39