### PR TITLE
Update gitignore for backend build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ lms-frontend/node_modules/
 
 lms-frontend/dist/
 lms-frontend/.env
+
+lms-backend/target/


### PR DESCRIPTION
## Summary
- add `lms-backend/target/` to `.gitignore`

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687afa41057883309b36b42d2441fcaf