### PR TITLE
Add method security and hide admin routes

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 @Configuration
-@EnableMethodSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     @Autowired

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BookController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BookController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +46,7 @@ public class BookController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<BookDto> createBook(@RequestBody Book book) {
         Book saved = bookRepository.save(book);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -52,6 +54,7 @@ public class BookController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<BookDto> updateBook(@PathVariable Integer id,
                                               @RequestBody Book book) {
         if (!bookRepository.existsById(id)) {
@@ -63,6 +66,7 @@ public class BookController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteBook(@PathVariable Integer id) {
         if (!bookRepository.existsById(id)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class MemberController {
     private MemberRepository memberRepository;
 
     @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<MemberDto>> getAllMembers() {
         List<MemberDto> list = memberRepository.findAll()
                 .stream()
@@ -27,6 +29,7 @@ public class MemberController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<MemberDto> createMember(@RequestBody Member member) {
         Member saved = memberRepository.save(member);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -34,6 +37,7 @@ public class MemberController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<MemberDto> updateMember(@PathVariable Integer id,
                                                   @RequestBody Member member) {
         if (!memberRepository.existsById(id)) {
@@ -45,6 +49,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteMember(@PathVariable Integer id) {
         if (!memberRepository.existsById(id)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/UserController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/UserController.java
@@ -6,6 +6,7 @@ import com.mohammadnizam.lms.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ public class UserController {
     private UserRepository userRepository;
 
     @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<UserDto>> getAllUsers() {
         List<UserDto> list = userRepository.findAll()
                 .stream()

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/AuthController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/AuthController.java
@@ -43,7 +43,8 @@ public class AuthController {
                 new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
         authenticationManager.authenticate(authToken);
         UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
-        String token = jwtUtil.generateToken(userDetails.getUsername());
+        User user = userRepository.findByUsername(userDetails.getUsername());
+        String token = jwtUtil.generateToken(user.getUsername(), user.getRole().name());
         return new AuthResponse(token);
     }
 
@@ -64,7 +65,7 @@ public class AuthController {
         member.setUser(user);
         memberRepository.save(member);
 
-        String token = jwtUtil.generateToken(user.getUsername());
+        String token = jwtUtil.generateToken(user.getUsername(), user.getRole().name());
         return new AuthResponse(token);
     }
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/security/JwtUtil.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/security/JwtUtil.java
@@ -35,7 +35,14 @@ public class JwtUtil {
     }
 
     public String generateToken(String username) {
+        return generateToken(username, null);
+    }
+
+    public String generateToken(String username, String role) {
         Map<String, Object> claims = new HashMap<>();
+        if (role != null) {
+            claims.put("role", role);
+        }
         return createToken(claims, username);
     }
 

--- a/lms-frontend/src/App.jsx
+++ b/lms-frontend/src/App.jsx
@@ -7,6 +7,7 @@ import BorrowRecordPage from './pages/BorrowRecordPage'
 import Dashboard from './pages/Dashboard'
 import SidebarLayout from './layouts/SidebarLayout'
 import ProtectedRoute from './routes/ProtectedRoute'
+import AdminRoute from './routes/AdminRoute'
 
 export default function App() {
   return (
@@ -22,8 +23,22 @@ export default function App() {
           }
         >
           <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/books" element={<BookListPage />} />
-          <Route path="/members" element={<MemberListPage />} />
+          <Route
+            path="/books"
+            element={
+              <AdminRoute>
+                <BookListPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="/members"
+            element={
+              <AdminRoute>
+                <MemberListPage />
+              </AdminRoute>
+            }
+          />
           <Route path="/borrow-records" element={<BorrowRecordPage />} />
         </Route>
       </Routes>

--- a/lms-frontend/src/components/Sidebar.jsx
+++ b/lms-frontend/src/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom'
+import { getUserRole } from '../utils/auth'
 
 export default function Sidebar() {
   const linkClass = ({ isActive }) =>
@@ -10,12 +11,16 @@ export default function Sidebar() {
         <NavLink to="/dashboard" className={linkClass}>
           Dashboard
         </NavLink>
-        <NavLink to="/books" className={linkClass}>
-          Books
-        </NavLink>
-        <NavLink to="/members" className={linkClass}>
-          Members
-        </NavLink>
+        {getUserRole() === 'ADMIN' && (
+          <>
+            <NavLink to="/books" className={linkClass}>
+              Books
+            </NavLink>
+            <NavLink to="/members" className={linkClass}>
+              Members
+            </NavLink>
+          </>
+        )}
         <NavLink to="/borrow-records" className={linkClass}>
           Borrow Records
         </NavLink>

--- a/lms-frontend/src/routes/AdminRoute.jsx
+++ b/lms-frontend/src/routes/AdminRoute.jsx
@@ -1,0 +1,14 @@
+import { Navigate } from 'react-router-dom'
+import { getUserRole } from '../utils/auth'
+
+export default function AdminRoute({ children }) {
+  const token = localStorage.getItem('token')
+  if (!token) {
+    return <Navigate to="/login" replace />
+  }
+  const role = getUserRole()
+  if (role !== 'ADMIN') {
+    return <Navigate to="/dashboard" replace />
+  }
+  return children
+}

--- a/lms-frontend/src/utils/auth.js
+++ b/lms-frontend/src/utils/auth.js
@@ -1,0 +1,10 @@
+export function getUserRole() {
+  const token = localStorage.getItem('token')
+  if (!token) return null
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    return payload.role || null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- restrict book and member CRUD APIs to admins
- enable method security in `SecurityConfig`
- include user role in generated JWT
- update login to embed role claim
- add admin-only navigation & routes in frontend

## Testing
- `mvn test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687afe7f53a48330897305bd3ce6efd8