### PR TITLE
Add book search endpoint and UI

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BookController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BookController.java
@@ -45,6 +45,22 @@ public class BookController {
         return ResponseEntity.ok(list);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<List<BookDto>> searchBooks(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String author,
+            @RequestParam(required = false) String category) {
+        String t = title != null ? title : "";
+        String a = author != null ? author : "";
+        String c = category != null ? category : "";
+        List<BookDto> list = bookRepository
+                .findByTitleContainingIgnoreCaseAndAuthorContainingIgnoreCaseAndCategoryContainingIgnoreCase(t, a, c)
+                .stream()
+                .map(BookDto::fromEntity)
+                .toList();
+        return ResponseEntity.ok(list);
+    }
+
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<BookDto> createBook(@RequestBody Book book) {

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BookRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BookRepository.java
@@ -9,4 +9,9 @@ import java.util.List;
 public interface BookRepository extends JpaRepository<Book, Integer> {
     List<Book> findByStatusOrCategory(BookStatus status, String category);
     List<Book> findByStatus(BookStatus status);
+    List<Book> findByTitleContainingIgnoreCase(String title);
+    List<Book> findByAuthorContainingIgnoreCase(String author);
+    List<Book> findByCategoryContainingIgnoreCase(String category);
+    List<Book> findByTitleContainingIgnoreCaseAndAuthorContainingIgnoreCaseAndCategoryContainingIgnoreCase(
+            String title, String author, String category);
 }

--- a/lms-frontend/src/pages/BookListPage.jsx
+++ b/lms-frontend/src/pages/BookListPage.jsx
@@ -3,6 +3,7 @@ import api from '../api/axios'
 
 export default function BookListPage() {
   const [books, setBooks] = useState([])
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
     const fetchBooks = async () => {
@@ -16,9 +17,33 @@ export default function BookListPage() {
     fetchBooks()
   }, [])
 
+  const handleSearch = async (e) => {
+    e.preventDefault()
+    try {
+      const { data } = await api.get('/books/search', {
+        params: { title: query },
+      })
+      setBooks(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Books</h1>
+      <form onSubmit={handleSearch} className="mb-4 flex gap-2">
+        <input
+          type="text"
+          placeholder="Search by title"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="border p-1 flex-1"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+          Search
+        </button>
+      </form>
       <ul className="space-y-2">
         {books.map((book) => (
           <li key={book.id} className="border p-2 rounded">


### PR DESCRIPTION
## Summary
- extend `BookRepository` with additional query methods
- implement `/api/books/search` controller route for searching books
- add a search form to the Book list page

## Testing
- `mvnw test` *(fails: Could not resolve Spring dependencies)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b0244a800833098cc67c082e5af89