### PR TITLE
Add renewal support and borrowing checks

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
@@ -13,18 +13,20 @@ public class BorrowRecordDto {
     private LocalDate dueDate;
     private LocalDate returnDate;
     private BigDecimal fine;
+    private Integer renewalCount;
 
     public BorrowRecordDto() {
     }
 
     public BorrowRecordDto(Integer recordId, Integer memberId, Integer bookId, LocalDate borrowDate,
-                           LocalDate dueDate, LocalDate returnDate, BigDecimal fine) {
+                           LocalDate dueDate, LocalDate returnDate, Integer renewalCount, BigDecimal fine) {
         this.recordId = recordId;
         this.memberId = memberId;
         this.bookId = bookId;
         this.borrowDate = borrowDate;
         this.dueDate = dueDate;
         this.returnDate = returnDate;
+        this.renewalCount = renewalCount;
         this.fine = fine;
     }
 
@@ -76,6 +78,14 @@ public class BorrowRecordDto {
         this.returnDate = returnDate;
     }
 
+    public Integer getRenewalCount() {
+        return renewalCount;
+    }
+
+    public void setRenewalCount(Integer renewalCount) {
+        this.renewalCount = renewalCount;
+    }
+
     public BigDecimal getFine() {
         return fine;
     }
@@ -99,6 +109,7 @@ public class BorrowRecordDto {
         dto.setBorrowDate(record.getBorrowDate());
         dto.setDueDate(record.getDueDate());
         dto.setReturnDate(record.getReturnDate());
+        dto.setRenewalCount(record.getRenewalCount());
         dto.setFine(record.getFine());
         return dto;
     }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/model/BorrowRecord.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/model/BorrowRecord.java
@@ -30,19 +30,23 @@ public class BorrowRecord {
     @Column(name = "return_date")
     private LocalDate returnDate;
 
+    @Column(name = "renewal_count")
+    private Integer renewalCount;
+
     private BigDecimal fine;
 
     public BorrowRecord() {
     }
 
     public BorrowRecord(Integer recordId, Member member, Book book, LocalDate borrowDate,
-                        LocalDate dueDate, LocalDate returnDate, BigDecimal fine) {
+                        LocalDate dueDate, LocalDate returnDate, Integer renewalCount, BigDecimal fine) {
         this.recordId = recordId;
         this.member = member;
         this.book = book;
         this.borrowDate = borrowDate;
         this.dueDate = dueDate;
         this.returnDate = returnDate;
+        this.renewalCount = renewalCount;
         this.fine = fine;
     }
 
@@ -92,6 +96,14 @@ public class BorrowRecord {
 
     public void setReturnDate(LocalDate returnDate) {
         this.returnDate = returnDate;
+    }
+
+    public Integer getRenewalCount() {
+        return renewalCount;
+    }
+
+    public void setRenewalCount(Integer renewalCount) {
+        this.renewalCount = renewalCount;
     }
 
     public BigDecimal getFine() {

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BorrowRecordRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BorrowRecordRepository.java
@@ -3,8 +3,16 @@ package com.mohammadnizam.lms.repository;
 import com.mohammadnizam.lms.model.BorrowRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface BorrowRecordRepository extends JpaRepository<BorrowRecord, Integer> {
     List<BorrowRecord> findByMember_MemberId(Integer memberId);
+
+    long countByMember_MemberIdAndReturnDateIsNull(Integer memberId);
+
+    boolean existsByMember_MemberIdAndFineGreaterThan(Integer memberId, BigDecimal amount);
+
+    boolean existsByMember_MemberIdAndDueDateBeforeAndReturnDateIsNull(Integer memberId, LocalDate date);
 }

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -44,6 +44,7 @@ CREATE TABLE borrow_records (
     borrow_date DATE,
     due_date DATE,
     return_date DATE,
+    renewal_count INT DEFAULT 0,
     fine DECIMAL(5,2) DEFAULT 0.00,
     FOREIGN KEY (member_id) REFERENCES members(member_id),
     FOREIGN KEY (book_id) REFERENCES books(book_id)


### PR DESCRIPTION
## Summary
- track borrow record renewals and database column
- enforce active borrow and fine checks when borrowing
- cap fines at $20 and charge $0.50/day
- add renew endpoint and integration tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b034632608330a874fd9ebedd6ebc