### PR TITLE
Add fines API and dashboard display

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/FineController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/FineController.java
@@ -1,0 +1,25 @@
+package com.mohammadnizam.lms.controller;
+
+import com.mohammadnizam.lms.repository.BorrowRecordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+
+@RestController
+@RequestMapping("/api/fines")
+public class FineController {
+
+    @Autowired
+    private BorrowRecordRepository borrowRecordRepository;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<BigDecimal> getOutstandingFines(@PathVariable Integer memberId) {
+        BigDecimal total = borrowRecordRepository.sumOutstandingFinesByMemberId(memberId);
+        if (total == null) {
+            total = BigDecimal.ZERO;
+        }
+        return ResponseEntity.ok(total);
+    }
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BorrowRecordRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/BorrowRecordRepository.java
@@ -2,6 +2,8 @@ package com.mohammadnizam.lms.repository;
 
 import com.mohammadnizam.lms.model.BorrowRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,4 +17,7 @@ public interface BorrowRecordRepository extends JpaRepository<BorrowRecord, Inte
     boolean existsByMember_MemberIdAndFineGreaterThan(Integer memberId, BigDecimal amount);
 
     boolean existsByMember_MemberIdAndDueDateBeforeAndReturnDateIsNull(Integer memberId, LocalDate date);
+
+    @Query("SELECT COALESCE(SUM(br.fine), 0) FROM BorrowRecord br WHERE br.member.memberId = :memberId AND br.fine > 0")
+    BigDecimal sumOutstandingFinesByMemberId(@Param("memberId") Integer memberId);
 }

--- a/lms-frontend/src/pages/Dashboard.jsx
+++ b/lms-frontend/src/pages/Dashboard.jsx
@@ -1,8 +1,42 @@
+import { useState } from 'react'
+import api from '../api/axios'
+
 export default function Dashboard() {
+  const [memberId, setMemberId] = useState('')
+  const [fine, setFine] = useState(null)
+
+  const fetchFine = async () => {
+    if (!memberId) return
+    try {
+      const { data } = await api.get(`/fines/${memberId}`)
+      setFine(parseFloat(data))
+    } catch (err) {
+      console.error(err)
+      setFine(null)
+    }
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <p>Summary stats will appear here.</p>
+      <div className="mb-4 flex gap-2 items-center">
+        <input
+          type="number"
+          placeholder="Member ID"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="border p-1"
+        />
+        <button
+          onClick={fetchFine}
+          className="bg-blue-500 text-white px-4 py-1 rounded"
+        >
+          Check Fines
+        </button>
+      </div>
+      {fine !== null && (
+        <div className="text-lg">Outstanding Fines: ${fine.toFixed(2)}</div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- support querying outstanding fines per member from the backend
- expose new endpoint `/api/fines/{memberId}`
- show outstanding fines on the dashboard in the frontend

## Testing
- `mvnw test` *(fails: could not resolve parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687b06e3e3c48330807bff413a067f10