### PR TITLE
Add React forms for books and members

### DIFF
--- a/lms-frontend/src/components/BookForm.jsx
+++ b/lms-frontend/src/components/BookForm.jsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from 'react'
+import api from '../api/axios'
+
+export default function BookForm({ book, onSuccess, onCancel }) {
+  const [form, setForm] = useState({
+    isbn: '',
+    title: '',
+    author: '',
+    category: '',
+    publicationYear: '',
+    copiesAvailable: '',
+    status: 'AVAILABLE',
+  })
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  useEffect(() => {
+    if (book) {
+      setForm({
+        isbn: book.isbn || '',
+        title: book.title || '',
+        author: book.author || '',
+        category: book.category || '',
+        publicationYear: book.publicationYear || '',
+        copiesAvailable: book.copiesAvailable || '',
+        status: book.status || 'AVAILABLE',
+      })
+    }
+  }, [book])
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setForm({ ...form, [name]: value })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    setSuccess('')
+    if (!form.title || !form.author) {
+      setError('Title and Author are required')
+      return
+    }
+    const payload = {
+      ...form,
+      publicationYear: form.publicationYear
+        ? parseInt(form.publicationYear)
+        : null,
+      copiesAvailable: form.copiesAvailable
+        ? parseInt(form.copiesAvailable)
+        : null,
+    }
+    try {
+      if (book && book.bookId) {
+        await api.put(`/books/${book.bookId}`, payload)
+      } else {
+        await api.post('/books', payload)
+      }
+      setSuccess('Saved successfully')
+      if (onSuccess) onSuccess()
+    } catch (err) {
+      console.error(err)
+      setError('Failed to save')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded bg-gray-50">
+      {error && <div className="text-red-600">{error}</div>}
+      {success && <div className="text-green-600">{success}</div>}
+      <div>
+        <input
+          name="isbn"
+          type="text"
+          placeholder="ISBN"
+          value={form.isbn}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <input
+          name="title"
+          type="text"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+          className="border p-1 w-full"
+          required
+        />
+      </div>
+      <div>
+        <input
+          name="author"
+          type="text"
+          placeholder="Author"
+          value={form.author}
+          onChange={handleChange}
+          className="border p-1 w-full"
+          required
+        />
+      </div>
+      <div>
+        <input
+          name="category"
+          type="text"
+          placeholder="Category"
+          value={form.category}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <input
+          name="publicationYear"
+          type="number"
+          placeholder="Publication Year"
+          value={form.publicationYear}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <input
+          name="copiesAvailable"
+          type="number"
+          placeholder="Copies Available"
+          value={form.copiesAvailable}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      {book && (
+        <div>
+          <select
+            name="status"
+            value={form.status}
+            onChange={handleChange}
+            className="border p-1 w-full"
+          >
+            <option value="AVAILABLE">AVAILABLE</option>
+            <option value="BORROWED">BORROWED</option>
+            <option value="RESERVED">RESERVED</option>
+          </select>
+        </div>
+      )}
+      <div className="flex gap-2">
+        <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+          Save
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} className="border px-4 py-1 rounded">
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/lms-frontend/src/components/MemberForm.jsx
+++ b/lms-frontend/src/components/MemberForm.jsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from 'react'
+import api from '../api/axios'
+
+export default function MemberForm({ member, onSuccess, onCancel }) {
+  const [form, setForm] = useState({
+    fullName: '',
+    contactInfo: '',
+    address: '',
+    membershipStart: '',
+    membershipEnd: '',
+  })
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  useEffect(() => {
+    if (member) {
+      setForm({
+        fullName: member.fullName || '',
+        contactInfo: member.contactInfo || '',
+        address: member.address || '',
+        membershipStart: member.membershipStart || '',
+        membershipEnd: member.membershipEnd || '',
+      })
+    }
+  }, [member])
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setForm({ ...form, [name]: value })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    setSuccess('')
+    if (!form.fullName) {
+      setError('Full name is required')
+      return
+    }
+    try {
+      const payload = { ...form }
+      if (member && member.memberId) {
+        await api.put(`/members/${member.memberId}`, payload)
+      } else {
+        await api.post('/members', payload)
+      }
+      setSuccess('Saved successfully')
+      if (onSuccess) onSuccess()
+    } catch (err) {
+      console.error(err)
+      setError('Failed to save')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded bg-gray-50">
+      {error && <div className="text-red-600">{error}</div>}
+      {success && <div className="text-green-600">{success}</div>}
+      <div>
+        <input
+          name="fullName"
+          type="text"
+          placeholder="Full Name"
+          value={form.fullName}
+          onChange={handleChange}
+          className="border p-1 w-full"
+          required
+        />
+      </div>
+      <div>
+        <input
+          name="contactInfo"
+          type="text"
+          placeholder="Contact Info"
+          value={form.contactInfo}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <input
+          name="address"
+          type="text"
+          placeholder="Address"
+          value={form.address}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <input
+          name="membershipStart"
+          type="date"
+          placeholder="Start"
+          value={form.membershipStart}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <input
+          name="membershipEnd"
+          type="date"
+          placeholder="End"
+          value={form.membershipEnd}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div className="flex gap-2">
+        <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+          Save
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} className="border px-4 py-1 rounded">
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/lms-frontend/src/pages/BookListPage.jsx
+++ b/lms-frontend/src/pages/BookListPage.jsx
@@ -1,19 +1,23 @@
 import { useEffect, useState } from 'react'
 import api from '../api/axios'
+import BookForm from '../components/BookForm'
 
 export default function BookListPage() {
   const [books, setBooks] = useState([])
   const [query, setQuery] = useState('')
+  const [showAdd, setShowAdd] = useState(false)
+  const [editBook, setEditBook] = useState(null)
+
+  const fetchBooks = async () => {
+    try {
+      const { data } = await api.get('/books')
+      setBooks(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
 
   useEffect(() => {
-    const fetchBooks = async () => {
-      try {
-        const { data } = await api.get('/books')
-        setBooks(data)
-      } catch (err) {
-        console.error(err)
-      }
-    }
     fetchBooks()
   }, [])
 
@@ -32,22 +36,53 @@ export default function BookListPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Books</h1>
-      <form onSubmit={handleSearch} className="mb-4 flex gap-2">
-        <input
-          type="text"
-          placeholder="Search by title"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="border p-1 flex-1"
-        />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
-          Search
+      <div className="mb-4 flex gap-2 items-center">
+        <form onSubmit={handleSearch} className="flex gap-2 flex-1">
+          <input
+            type="text"
+            placeholder="Search by title"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="border p-1 flex-1"
+          />
+          <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+            Search
+          </button>
+        </form>
+        <button
+          type="button"
+          onClick={() => setShowAdd((v) => !v)}
+          className="bg-green-500 text-white px-4 py-1 rounded"
+        >
+          {showAdd ? 'Close' : 'Add Book'}
         </button>
-      </form>
+      </div>
+      {showAdd && (
+        <div className="mb-4">
+          <BookForm onSuccess={() => { setShowAdd(false); fetchBooks(); }} onCancel={() => setShowAdd(false)} />
+        </div>
+      )}
       <ul className="space-y-2">
         {books.map((book) => (
-          <li key={book.id} className="border p-2 rounded">
-            {book.title}
+          <li key={book.bookId} className="border p-2 rounded">
+            <div className="flex justify-between items-center">
+              <span>{book.title}</span>
+              <button
+                className="text-blue-600 underline"
+                onClick={() => setEditBook(book)}
+              >
+                Edit
+              </button>
+            </div>
+            {editBook && editBook.bookId === book.bookId && (
+              <div className="mt-2">
+                <BookForm
+                  book={editBook}
+                  onSuccess={() => { setEditBook(null); fetchBooks(); }}
+                  onCancel={() => setEditBook(null)}
+                />
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/lms-frontend/src/pages/MemberListPage.jsx
+++ b/lms-frontend/src/pages/MemberListPage.jsx
@@ -1,28 +1,63 @@
 import { useEffect, useState } from 'react'
 import api from '../api/axios'
+import MemberForm from '../components/MemberForm'
 
 export default function MemberListPage() {
   const [members, setMembers] = useState([])
+  const [showAdd, setShowAdd] = useState(false)
+  const [editMember, setEditMember] = useState(null)
+
+  const fetchMembers = async () => {
+    try {
+      const { data } = await api.get('/members')
+      setMembers(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
 
   useEffect(() => {
-    const fetchMembers = async () => {
-      try {
-        const { data } = await api.get('/members')
-        setMembers(data)
-      } catch (err) {
-        console.error(err)
-      }
-    }
     fetchMembers()
   }, [])
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Members</h1>
+      <div className="mb-4 flex justify-end">
+        <button
+          type="button"
+          onClick={() => setShowAdd((v) => !v)}
+          className="bg-green-500 text-white px-4 py-1 rounded"
+        >
+          {showAdd ? 'Close' : 'Add Member'}
+        </button>
+      </div>
+      {showAdd && (
+        <div className="mb-4">
+          <MemberForm onSuccess={() => { setShowAdd(false); fetchMembers(); }} onCancel={() => setShowAdd(false)} />
+        </div>
+      )}
       <ul className="space-y-2">
         {members.map((m) => (
-          <li key={m.id} className="border p-2 rounded">
-            {m.name}
+          <li key={m.memberId} className="border p-2 rounded">
+            <div className="flex justify-between items-center">
+              <span>{m.fullName}</span>
+              <button
+                className="text-blue-600 underline"
+                onClick={() => setEditMember(m)}
+              >
+                Edit
+              </button>
+            </div>
+            {editMember && editMember.memberId === m.memberId && (
+              <div className="mt-2">
+                <MemberForm
+                  member={editMember}
+                  onSuccess={() => { setEditMember(null); fetchMembers(); }}
+                  onCancel={() => setEditMember(null)}
+                />
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- create `BookForm` and `MemberForm` reusable components
- integrate new forms in `BookListPage` and `MemberListPage`
- allow add/edit functionality hooked up to backend APIs
- display simple validation and success/error messages

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b0e492ca88330988a17e84391b2b0