### PR TITLE
Add controller and repository tests

### DIFF
--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/MemberControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/MemberControllerTest.java
@@ -1,0 +1,76 @@
+package com.mohammadnizam.lms.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mohammadnizam.lms.model.Member;
+import com.mohammadnizam.lms.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(MemberControllerTest.MockConfig.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @TestConfiguration
+    static class MockConfig {
+        @Bean
+        MemberRepository memberRepository() {
+            return Mockito.mock(MemberRepository.class);
+        }
+    }
+
+    @Test
+    void getAllMembers_returnsList() throws Exception {
+        Member member = new Member();
+        member.setMemberId(1);
+        member.setFullName("John Doe");
+        member.setContactInfo("123");
+        member.setAddress("Addr");
+        member.setMembershipStart(LocalDate.now());
+        member.setMembershipEnd(LocalDate.now().plusDays(1));
+        given(memberRepository.findAll()).willReturn(List.of(member));
+
+        mockMvc.perform(get("/api/members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].fullName").value("John Doe"));
+    }
+
+    @Test
+    void createMember_returnsCreated() throws Exception {
+        Member member = new Member();
+        member.setMemberId(1);
+        member.setFullName("Jane");
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        mockMvc.perform(post("/api/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(member)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.memberId").value(1));
+    }
+}

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/repository/BookRepositoryTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/repository/BookRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.mohammadnizam.lms.repository;
+
+import com.mohammadnizam.lms.model.Book;
+import com.mohammadnizam.lms.model.BookStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookRepositoryTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Test
+    void findByTitleContainingIgnoreCase_returnsMatches() {
+        Book book = new Book();
+        book.setIsbn("987");
+        book.setTitle("Spring Boot Guide");
+        book.setAuthor("John");
+        book.setCategory("Tech");
+        book.setPublicationYear(2024);
+        book.setCopiesAvailable(2);
+        book.setStatus(BookStatus.AVAILABLE);
+        book = bookRepository.save(book);
+
+        List<Book> results = bookRepository.findByTitleContainingIgnoreCase("spring");
+        assertThat(results).extracting(Book::getBookId).contains(book.getBookId());
+    }
+}


### PR DESCRIPTION
## Summary
- add MemberControllerTest using MockMvc
- add BookRepositoryTest for custom query

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b0fdb71748330ab18393183957295