### PR TITLE
Add member search feature

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
@@ -28,6 +28,17 @@ public class MemberController {
         return ResponseEntity.ok(list);
     }
 
+    @GetMapping("/search")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<MemberDto>> searchMembers(@RequestParam(required = false) String name) {
+        String n = name != null ? name : "";
+        List<MemberDto> list = memberRepository.findByFullNameContainingIgnoreCase(n)
+                .stream()
+                .map(MemberDto::fromEntity)
+                .toList();
+        return ResponseEntity.ok(list);
+    }
+
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<MemberDto> createMember(@RequestBody Member member) {

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/MemberRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package com.mohammadnizam.lms.repository;
 import com.mohammadnizam.lms.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberRepository extends JpaRepository<Member, Integer> {
+    List<Member> findByFullNameContainingIgnoreCase(String name);
 }

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/MemberControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/MemberControllerTest.java
@@ -73,4 +73,17 @@ class MemberControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.memberId").value(1));
     }
+
+    @Test
+    void searchMembers_returnsList() throws Exception {
+        Member member = new Member();
+        member.setMemberId(2);
+        member.setFullName("Alice");
+        given(memberRepository.findByFullNameContainingIgnoreCase("Alice"))
+                .willReturn(List.of(member));
+
+        mockMvc.perform(get("/api/members/search").param("name", "Alice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].fullName").value("Alice"));
+    }
 }

--- a/lms-frontend/src/pages/MemberListPage.jsx
+++ b/lms-frontend/src/pages/MemberListPage.jsx
@@ -4,12 +4,25 @@ import MemberForm from '../components/MemberForm'
 
 export default function MemberListPage() {
   const [members, setMembers] = useState([])
+  const [query, setQuery] = useState('')
   const [showAdd, setShowAdd] = useState(false)
   const [editMember, setEditMember] = useState(null)
 
   const fetchMembers = async () => {
     try {
       const { data } = await api.get('/members')
+      setMembers(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleSearch = async (e) => {
+    e.preventDefault()
+    try {
+      const { data } = await api.get('/members/search', {
+        params: { name: query },
+      })
       setMembers(data)
     } catch (err) {
       console.error(err)
@@ -23,7 +36,19 @@ export default function MemberListPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Members</h1>
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 flex gap-2 items-center">
+        <form onSubmit={handleSearch} className="flex gap-2 flex-1">
+          <input
+            type="text"
+            placeholder="Search by name"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="border p-1 flex-1"
+          />
+          <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+            Search
+          </button>
+        </form>
         <button
           type="button"
           onClick={() => setShowAdd((v) => !v)}


### PR DESCRIPTION
## Summary
- add search query method on `MemberRepository`
- expose `/api/members/search` endpoint in `MemberController`
- update Member controller tests for search
- add member search input in React frontend

## Testing
- `./mvnw test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b17892e5c8330ace2e88e149d2b64