### PR TITLE
Configure jwt.secret via properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,23 +44,28 @@ Entities include `users`, `books`, `members`, `borrow_transactions` and `reserva
 
 ## Setup
 1. Create the database `lms_db` and run `sql/create_tables.sql`.
-2. (Optional) Seed sample data with hashed passwords:
+2. Configure a JWT secret in `lms-backend/src/main/resources/application.properties`:
+   ```properties
+   jwt.secret=BASE64_ENCODED_SECRET
+   ```
+   You can generate one with `openssl rand -base64 32`.
+3. (Optional) Seed sample data with hashed passwords:
    ```bash
    mysql -u root -p lms_db < sql/insert_sample_data.sql
    ```
    Default logins include `admin/admin123` for an admin user.
-3. Start the backend:
+4. Start the backend:
    ```bash
    cd lms-backend
    ./mvnw spring-boot:run
    ```
-4. Start the frontend:
+5. Start the frontend:
    ```bash
    cd lms-frontend
    npm install
    npm run dev
    ```
-5. Open `http://localhost:5173` in a browser.
+6. Open `http://localhost:5173` in a browser.
 
 ## Tests
 Backend unit tests can be executed with:

--- a/lms-backend/README.md
+++ b/lms-backend/README.md
@@ -9,11 +9,16 @@ This module contains the Spring Boot application for the **Library Management Sy
 
 ## Setup
 1. Ensure MySQL is running and execute `../sql/create_tables.sql` to create tables.
-2. Run the application:
+2. Set a JWT signing secret in `src/main/resources/application.properties`:
+   ```properties
+   jwt.secret=BASE64_ENCODED_SECRET
+   ```
+   You can generate one with `openssl rand -base64 32`.
+3. Run the application:
    ```bash
    ./mvnw spring-boot:run
    ```
-3. The API will be available at `http://localhost:8081/api/`.
+4. The API will be available at `http://localhost:8081/api/`.
 
 ## Common Endpoints
 - `POST /api/auth/register` – user registration

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/security/JwtUtil.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/security/JwtUtil.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -16,12 +17,12 @@ import java.util.function.Function;
 @Component
 public class JwtUtil {
 
-    // Simple static secret for demo purposes
-    private static final String SECRET = "746869732d69732d612d766572792d7365637265742d6b65792d313233";
+    @Value("${jwt.secret}")
+    private String secret;
     private static final long EXPIRATION_MS = 1000 * 60 * 60; // 1 hour
 
     private Key getSignInKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(SECRET);
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
         return Keys.hmacShaKeyFor(keyBytes);
     }
 

--- a/lms-backend/src/main/resources/application.properties
+++ b/lms-backend/src/main/resources/application.properties
@@ -15,5 +15,9 @@ server.port=8081
 logging.level.org.springframework=INFO
 logging.level.com.mohammadnizam=DEBUG
 
+# === JWT ===
+# Replace with your own Base64 encoded secret key
+jwt.secret=CHANGE_ME
+
 # Allow Spring MVC to dispatch OPTIONS requests so CORS configuration applies
 spring.mvc.dispatch-options-request=true

--- a/lms-backend/src/test/resources/application.properties
+++ b/lms-backend/src/test/resources/application.properties
@@ -3,3 +3,6 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
+
+# Default secret for tests (Base64 encoded)
+jwt.secret=dGVzdC1zZWNyZXQta2V5


### PR DESCRIPTION
## Summary
- allow `JwtUtil` to pull the signing secret from configuration
- document `jwt.secret` in README files
- add placeholders in `application.properties`
- provide test `jwt.secret` for Spring tests

## Testing
- `mvnw test` *(fails: Could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b1898a94483308f31b98dd164fb53