### PR TITLE
Add overdue notification emails

### DIFF
--- a/lms-backend/pom.xml
+++ b/lms-backend/pom.xml
@@ -41,6 +41,12 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <!-- Spring Boot Mail -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
         <!-- MySQL JDBC Driver -->
         <dependency>
             <groupId>com.mysql</groupId>

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/scheduler/OverdueScheduler.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/scheduler/OverdueScheduler.java
@@ -2,6 +2,7 @@ package com.mohammadnizam.lms.scheduler;
 
 import com.mohammadnizam.lms.model.BorrowRecord;
 import com.mohammadnizam.lms.repository.BorrowRecordRepository;
+import com.mohammadnizam.lms.service.NotificationService;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -19,6 +20,9 @@ public class OverdueScheduler {
     @Autowired
     private BorrowRecordRepository borrowRecordRepository;
 
+    @Autowired
+    private NotificationService notificationService;
+
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void updateOverdueFines() {
@@ -35,5 +39,7 @@ public class OverdueScheduler {
                 borrowRecordRepository.save(record);
             }
         }
+
+        notificationService.sendOverdueNotifications();
     }
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/service/NotificationService.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/service/NotificationService.java
@@ -1,0 +1,53 @@
+package com.mohammadnizam.lms.service;
+
+import com.mohammadnizam.lms.model.BorrowRecord;
+import com.mohammadnizam.lms.model.Member;
+import com.mohammadnizam.lms.repository.BorrowRecordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class NotificationService {
+
+    @Autowired
+    private BorrowRecordRepository borrowRecordRepository;
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Value("${mail.from:library@example.com}")
+    private String fromAddress;
+
+    public void sendOverdueNotifications() {
+        LocalDate today = LocalDate.now();
+        List<BorrowRecord> overdue = borrowRecordRepository
+                .findByDueDateBeforeAndReturnDateIsNull(today);
+        Map<Member, List<BorrowRecord>> byMember = overdue.stream()
+                .collect(Collectors.groupingBy(BorrowRecord::getMember));
+
+        for (Map.Entry<Member, List<BorrowRecord>> entry : byMember.entrySet()) {
+            Member member = entry.getKey();
+            String email = member.getContactInfo();
+            if (email == null || email.isBlank()) {
+                continue;
+            }
+            String titles = entry.getValue().stream()
+                    .map(br -> br.getBook().getTitle())
+                    .collect(Collectors.joining(", "));
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setFrom(fromAddress);
+            message.setTo(email);
+            message.setSubject("Overdue Library Items");
+            message.setText("You have overdue items: " + titles);
+            mailSender.send(message);
+        }
+    }
+}

--- a/lms-backend/src/main/resources/application.properties
+++ b/lms-backend/src/main/resources/application.properties
@@ -21,3 +21,12 @@ jwt.secret=CHANGE_ME
 
 # Allow Spring MVC to dispatch OPTIONS requests so CORS configuration applies
 spring.mvc.dispatch-options-request=true
+
+# === Email Settings ===
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=user@example.com
+spring.mail.password=secret
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+mail.from=library@example.com

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceIntegrationTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.mohammadnizam.lms.service;
+
+import com.mohammadnizam.lms.model.Book;
+import com.mohammadnizam.lms.model.BorrowRecord;
+import com.mohammadnizam.lms.model.Member;
+import com.mohammadnizam.lms.repository.BorrowRecordRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class NotificationServiceIntegrationTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @MockBean
+    private BorrowRecordRepository borrowRecordRepository;
+
+    @MockBean
+    private JavaMailSender mailSender;
+
+    @Test
+    void sendOverdueNotifications_invokedInSpringContext() {
+        Member member = new Member();
+        member.setContactInfo("test@example.com");
+        Book book = new Book();
+        book.setTitle("Title");
+        BorrowRecord record = new BorrowRecord();
+        record.setMember(member);
+        record.setBook(book);
+        record.setDueDate(LocalDate.now().minusDays(1));
+
+        when(borrowRecordRepository.findByDueDateBeforeAndReturnDateIsNull(any(LocalDate.class)))
+                .thenReturn(List.of(record));
+
+        notificationService.sendOverdueNotifications();
+
+        verify(mailSender, times(1)).send(any());
+    }
+}

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceTest.java
@@ -1,0 +1,61 @@
+package com.mohammadnizam.lms.service;
+
+import com.mohammadnizam.lms.model.Book;
+import com.mohammadnizam.lms.model.BorrowRecord;
+import com.mohammadnizam.lms.model.Member;
+import com.mohammadnizam.lms.repository.BorrowRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class NotificationServiceTest {
+
+    @Mock
+    private BorrowRecordRepository borrowRecordRepository;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void sendOverdueNotifications_sendsEmailForOverdue() {
+        Member member = new Member();
+        member.setContactInfo("user@example.com");
+        Book book = new Book();
+        book.setTitle("Test Book");
+        BorrowRecord record = new BorrowRecord();
+        record.setMember(member);
+        record.setBook(book);
+        record.setDueDate(LocalDate.now().minusDays(1));
+
+        when(borrowRecordRepository.findByDueDateBeforeAndReturnDateIsNull(any(LocalDate.class)))
+                .thenReturn(List.of(record));
+
+        notificationService.sendOverdueNotifications();
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender, times(1)).send(captor.capture());
+        SimpleMailMessage msg = captor.getValue();
+        assertThat(msg.getTo()[0]).isEqualTo("user@example.com");
+        assertThat(msg.getText()).contains("Test Book");
+    }
+}


### PR DESCRIPTION
## Summary
- add `NotificationService` to email members about overdue books
- wire the service into `OverdueScheduler`
- configure spring mail settings in `application.properties`
- include mail starter in Maven build
- add unit and integration tests for notifications

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687b1b89c8088330a1051ad0d29331e6