### PR TITLE
Add endpoints for current user borrow/reservation lists

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BorrowRecordController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/BorrowRecordController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -61,6 +62,19 @@ public class BorrowRecordController {
     @GetMapping("/member/{memberId}")
     public ResponseEntity<List<BorrowRecordDto>> getRecordsByMember(@PathVariable Integer memberId) {
         List<BorrowRecordDto> list = borrowRecordRepository.findByMember_MemberId(memberId)
+                .stream()
+                .map(BorrowRecordDto::fromEntity)
+                .toList();
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<BorrowRecordDto>> getMyRecords(@AuthenticationPrincipal(expression = "username") String username) {
+        Optional<Member> memberOpt = memberRepository.findByUser_Username(username);
+        if (memberOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        List<BorrowRecordDto> list = borrowRecordRepository.findByMember_MemberId(memberOpt.get().getMemberId())
                 .stream()
                 .map(BorrowRecordDto::fromEntity)
                 .toList();

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/ReservationController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/ReservationController.java
@@ -9,6 +9,7 @@ import com.mohammadnizam.lms.repository.BookRepository;
 import com.mohammadnizam.lms.repository.MemberRepository;
 import com.mohammadnizam.lms.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,6 +34,19 @@ public class ReservationController {
     @GetMapping
     public ResponseEntity<List<ReservationDto>> getAll() {
         List<ReservationDto> list = reservationRepository.findAll()
+                .stream()
+                .map(ReservationDto::fromEntity)
+                .toList();
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<ReservationDto>> getMyReservations(@AuthenticationPrincipal(expression = "username") String username) {
+        Optional<Member> memberOpt = memberRepository.findByUser_Username(username);
+        if (memberOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        List<ReservationDto> list = reservationRepository.findByMember_MemberId(memberOpt.get().getMemberId())
                 .stream()
                 .map(ReservationDto::fromEntity)
                 .toList();

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/MemberRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/MemberRepository.java
@@ -4,7 +4,10 @@ import com.mohammadnizam.lms.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Integer> {
     List<Member> findByFullNameContainingIgnoreCase(String name);
+
+    Optional<Member> findByUser_Username(String username);
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/ReservationRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/ReservationRepository.java
@@ -11,4 +11,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Intege
     List<Reservation> findByBook_BookIdAndStatus(Integer bookId, ReservationStatus status);
     Optional<Reservation> findByBook_BookIdAndMember_MemberIdAndStatus(Integer bookId, Integer memberId, ReservationStatus status);
     boolean existsByBook_BookIdAndStatus(Integer bookId, ReservationStatus status);
+
+    List<Reservation> findByMember_MemberId(Integer memberId);
 }

--- a/lms-frontend/src/pages/BorrowRecordPage.jsx
+++ b/lms-frontend/src/pages/BorrowRecordPage.jsx
@@ -8,7 +8,7 @@ export default function BorrowRecordPage() {
 
   const fetchRecords = async () => {
     try {
-      const { data } = await api.get('/borrow-records')
+      const { data } = await api.get('/borrow-records/my')
       setRecords(data)
     } catch (err) {
       console.error(err)

--- a/lms-frontend/src/pages/ReservationPage.jsx
+++ b/lms-frontend/src/pages/ReservationPage.jsx
@@ -8,7 +8,7 @@ export default function ReservationPage() {
 
   const fetchReservations = async () => {
     try {
-      const { data } = await api.get('/reservations')
+      const { data } = await api.get('/reservations/my')
       setReservations(data)
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
## Summary
- add repository methods to resolve a member by username and list reservations by member
- expose `/api/borrow-records/my` and `/api/reservations/my` endpoints using `@AuthenticationPrincipal`
- call these endpoints from BorrowRecordPage and ReservationPage

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b1ca72d0c8330b8a9f43046000803