### PR TITLE
Add springdoc OpenAPI support

### DIFF
--- a/lms-backend/pom.xml
+++ b/lms-backend/pom.xml
@@ -84,6 +84,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Springdoc OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/config/OpenApiConfig.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/config/OpenApiConfig.java
@@ -1,0 +1,15 @@
+package com.mohammadnizam.lms.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "Library Management System API", version = "1.0",
+                description = "API documentation for the LMS"),
+        servers = @Server(url = "/", description = "Default")
+)
+public class OpenApiConfig {
+}

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/auth/login").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))


### PR DESCRIPTION
## Summary
- add springdoc-openapi dependency
- configure OpenAPI documentation metadata
- expose swagger endpoints through security configuration

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM because repo.maven.apache.org is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687b23d10b7c83309865b532a5670d6c