### PR TITLE
Fix ambiguous JavaMailSender.send verification

### DIFF
--- a/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceIntegrationTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.SimpleMailMessage;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,6 +45,6 @@ class NotificationServiceIntegrationTest {
 
         notificationService.sendOverdueNotifications();
 
-        verify(mailSender, times(1)).send(any());
+        verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
     }
 }


### PR DESCRIPTION
## Summary
- update integration test to verify `JavaMailSender.send` using `SimpleMailMessage`

## Testing
- `./mvnw test` *(fails: could not resolve Maven dependencies - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687b2b49480c8330af64730e159f917a