### PR TITLE
Allow unauthenticated registration

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceIntegrationTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/service/NotificationServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.SimpleMailMessage;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,6 +45,6 @@ class NotificationServiceIntegrationTest {
 
         notificationService.sendOverdueNotifications();
 
-        verify(mailSender, times(1)).send(any());
+        verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
     }
 }


### PR DESCRIPTION
## Summary
- permit `/api/auth/register` in security config so new users can register

## Testing
- `./mvnw test` *(fails: could not resolve Maven dependencies - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687b2b49480c8330af64730e159f917a