### PR TITLE
Handle AuthenticationException on login

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/AuthController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/auth/AuthController.java
@@ -43,10 +43,14 @@ public class AuthController {
     private PasswordEncoder passwordEncoder;
 
     @PostMapping("/login")
-    public AuthResponse login(@RequestBody AuthRequest request) throws AuthenticationException {
+    public AuthResponse login(@RequestBody AuthRequest request) {
         UsernamePasswordAuthenticationToken authToken =
                 new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
-        authenticationManager.authenticate(authToken);
+        try {
+            authenticationManager.authenticate(authToken);
+        } catch (AuthenticationException ex) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid username or password");
+        }
         UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
         User user = userRepository.findByUsername(userDetails.getUsername());
         String token = jwtUtil.generateToken(user.getUsername(), user.getRole().name());

--- a/lms-backend/src/test/java/com/mohammadnizam/lms/controller/AuthControllerTest.java
+++ b/lms-backend/src/test/java/com/mohammadnizam/lms/controller/AuthControllerTest.java
@@ -1,0 +1,66 @@
+package com.mohammadnizam.lms.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mohammadnizam.lms.controller.auth.AuthController;
+import com.mohammadnizam.lms.controller.auth.AuthRequest;
+import com.mohammadnizam.lms.security.JwtUtil;
+import com.mohammadnizam.lms.repository.UserRepository;
+import com.mohammadnizam.lms.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void login_withBadCredentials_returns401() throws Exception {
+        AuthRequest request = new AuthRequest("bad", "creds");
+
+        given(authenticationManager.authenticate(any()))
+                .willThrow(new BadCredentialsException("bad"));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- catch `AuthenticationException` inside `AuthController.login()` and throw `ResponseStatusException` with a 401 status
- add `AuthControllerTest` covering failed login

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687b44c884b483309f1b4eeddae67b0a