### PR TITLE
Improve HomePage UI with SVG icons and theming

### DIFF
--- a/lms-frontend/src/assets/icons/BookIcon.jsx
+++ b/lms-frontend/src/assets/icons/BookIcon.jsx
@@ -1,0 +1,13 @@
+export default function BookIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M6 4a2 2 0 012-2h11v2H8v14h11v2H8a2 2 0 01-2-2V4z" />
+      <path d="M18 4h2a2 2 0 012 2v14a2 2 0 01-2 2h-2V4z" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/RecordIcon.jsx
+++ b/lms-frontend/src/assets/icons/RecordIcon.jsx
@@ -1,0 +1,14 @@
+export default function RecordIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5M3.75 14.25h16.5M3.75 18.75h8.25" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/SearchIcon.jsx
+++ b/lms-frontend/src/assets/icons/SearchIcon.jsx
@@ -1,0 +1,14 @@
+export default function SearchIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/UserIcon.jsx
+++ b/lms-frontend/src/assets/icons/UserIcon.jsx
@@ -1,0 +1,15 @@
+export default function UserIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 7.5a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 21a7.5 7.5 0 0115 0" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/components/ui/Button.jsx
+++ b/lms-frontend/src/components/ui/Button.jsx
@@ -1,0 +1,11 @@
+export default function Button({ as = 'button', children, className = '', ...props }) {
+  const Component = as
+  return (
+    <Component
+      className={`px-6 py-3 rounded-md font-semibold text-white transition-colors hover:opacity-90 active:opacity-80 ${className}`}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/lms-frontend/src/components/ui/Card.jsx
+++ b/lms-frontend/src/components/ui/Card.jsx
@@ -1,0 +1,5 @@
+export default function Card({ children, className = '' }) {
+  return (
+    <div className={`bg-white rounded-md shadow-md p-6 ${className}`}>{children}</div>
+  )
+}

--- a/lms-frontend/src/index.css
+++ b/lms-frontend/src/index.css
@@ -1,3 +1,4 @@
+@import './theme.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/lms-frontend/src/pages/HomePage.jsx
+++ b/lms-frontend/src/pages/HomePage.jsx
@@ -1,4 +1,9 @@
 import { Link } from 'react-router-dom'
+import Button from '../components/ui/Button'
+import BookIcon from '../assets/icons/BookIcon'
+import UserIcon from '../assets/icons/UserIcon'
+import RecordIcon from '../assets/icons/RecordIcon'
+import Card from '../components/ui/Card'
 
 export default function HomePage() {
   return (
@@ -6,74 +11,51 @@ export default function HomePage() {
       {/* Hero Section */}
       <header
         className="relative h-96 bg-center bg-cover"
-        style={{
-          backgroundImage:
-            "url('https://source.unsplash.com/1600x900/?library')",
-        }}
+        style={{ backgroundImage: "url('https://source.unsplash.com/1600x900/?library')" }}
       >
-        <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center text-white text-center px-4">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Welcome to Our Library
-          </h1>
+        <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/20 flex flex-col items-center justify-center text-white text-center px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Welcome to Our Library</h1>
           <p className="mb-6 text-lg md:text-xl max-w-2xl">
-            Explore, manage and borrow books with ease through our Library
-            Management System.
+            Explore, manage and borrow books with ease through our Library Management System.
           </p>
           <div className="flex gap-4">
-            <Link
-              to="/login"
-              className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded"
-            >
+            <Button as={Link} to="/login" className="bg-primary">
               Login
-            </Link>
-            <Link
-              to="/register"
-              className="bg-green-500 hover:bg-green-600 text-white px-6 py-3 rounded"
-            >
+            </Button>
+            <Button as={Link} to="/register" className="bg-secondary">
               Register
-            </Link>
+            </Button>
           </div>
         </div>
       </header>
 
       {/* Features Section */}
-      <section className="flex-1 py-12 px-4 bg-gray-50">
+      <section className="flex-1 py-12 px-4 bg-background">
         <h2 className="text-3xl font-bold text-center mb-8">Features</h2>
         <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
-          <div className="bg-white p-6 rounded shadow">
-            <h3 className="text-xl font-semibold mb-2">
-              Book Search and Borrowing
-            </h3>
-            <p className="text-gray-600">
-              Find the books you need quickly and check them out effortlessly.
-            </p>
-          </div>
-          <div className="bg-white p-6 rounded shadow">
-            <h3 className="text-xl font-semibold mb-2">Member Management</h3>
-            <p className="text-gray-600">
-              Manage library members, their information and privileges with
-              ease.
-            </p>
-          </div>
-          <div className="bg-white p-6 rounded shadow">
-            <h3 className="text-xl font-semibold mb-2">
-              Borrowing Records Tracking
-            </h3>
-            <p className="text-gray-600">
-              Keep track of borrowed books and due dates in one convenient
-              place.
-            </p>
-          </div>
+          <Card className="text-center space-y-2">
+            <BookIcon className="w-10 h-10 mx-auto text-primary" />
+            <h3 className="text-xl font-semibold">Book Search and Borrowing</h3>
+            <p className="text-gray-600">Find books quickly and check them out effortlessly.</p>
+          </Card>
+          <Card className="text-center space-y-2">
+            <UserIcon className="w-10 h-10 mx-auto text-primary" />
+            <h3 className="text-xl font-semibold">Member Management</h3>
+            <p className="text-gray-600">Manage library members and privileges with ease.</p>
+          </Card>
+          <Card className="text-center space-y-2">
+            <RecordIcon className="w-10 h-10 mx-auto text-primary" />
+            <h3 className="text-xl font-semibold">Borrowing Records Tracking</h3>
+            <p className="text-gray-600">Keep track of borrowed books and due dates in one place.</p>
+          </Card>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="bg-gray-800 text-white text-center py-4">
+      <footer className="bg-primary text-white text-center py-4 mt-auto">
         <div className="font-semibold">Library Management System</div>
         <div>contact@library.com</div>
-        <div className="text-sm mt-1">
-          &copy; {new Date().getFullYear()} Library
-        </div>
+        <div className="text-sm mt-1">&copy; {new Date().getFullYear()} Library</div>
       </footer>
     </div>
   )

--- a/lms-frontend/src/theme.css
+++ b/lms-frontend/src/theme.css
@@ -1,0 +1,14 @@
+:root {
+  --color-primary: #2563eb;
+  --color-secondary: #16a34a;
+  --color-background: #f8fafc;
+  --color-text: #1e293b;
+  --font-base: 'Inter', sans-serif;
+  --radius: 0.5rem;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-base);
+}

--- a/lms-frontend/tailwind.config.js
+++ b/lms-frontend/tailwind.config.js
@@ -2,7 +2,20 @@
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: 'var(--color-primary)',
+        secondary: 'var(--color-secondary)',
+        background: 'var(--color-background)',
+        text: 'var(--color-text)',
+      },
+      fontFamily: {
+        base: 'var(--font-base)',
+      },
+      borderRadius: {
+        DEFAULT: 'var(--radius)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add design tokens via `theme.css`
- extend tailwind to reference CSS variables
- import theme in global styles
- introduce reusable `Button` and `Card` UI components
- add inline SVG icons (book, user, record, search)
- redesign `HomePage` with modern layout and icons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b45e6ed508330930cfaee4a758acf