### PR TITLE
Improve HomePage UI with SVG icons and theming

### DIFF
--- a/lms-frontend/src/assets/icons/BookIcon.jsx
+++ b/lms-frontend/src/assets/icons/BookIcon.jsx
@@ -1,0 +1,13 @@
+export default function BookIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M6 4a2 2 0 012-2h11v2H8v14h11v2H8a2 2 0 01-2-2V4z" />
+      <path d="M18 4h2a2 2 0 012 2v14a2 2 0 01-2 2h-2V4z" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/BorrowIcon.jsx
+++ b/lms-frontend/src/assets/icons/BorrowIcon.jsx
@@ -1,0 +1,14 @@
+export default function BorrowIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 12l-6 6m6-6l-6-6m6 6H3" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/CalendarIcon.jsx
+++ b/lms-frontend/src/assets/icons/CalendarIcon.jsx
@@ -1,0 +1,14 @@
+export default function CalendarIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 2v4m12-4v4M3 8h18M4 8v12h16V8" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/FineIcon.jsx
+++ b/lms-frontend/src/assets/icons/FineIcon.jsx
@@ -1,0 +1,14 @@
+export default function FineIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m0-9.5c-2 0-3.5 1-3.5 2.5S10 13.5 12 13.5s3.5 1 3.5 2.5S14 18 12 18" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/RecordIcon.jsx
+++ b/lms-frontend/src/assets/icons/RecordIcon.jsx
@@ -1,0 +1,14 @@
+export default function RecordIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5M3.75 14.25h16.5M3.75 18.75h8.25" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/ReturnIcon.jsx
+++ b/lms-frontend/src/assets/icons/ReturnIcon.jsx
@@ -1,0 +1,14 @@
+export default function ReturnIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 12l6-6m-6 6l6 6m-6-6h13.5" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/SearchIcon.jsx
+++ b/lms-frontend/src/assets/icons/SearchIcon.jsx
@@ -1,0 +1,14 @@
+export default function SearchIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/assets/icons/UserIcon.jsx
+++ b/lms-frontend/src/assets/icons/UserIcon.jsx
@@ -1,0 +1,15 @@
+export default function UserIcon({className="w-6 h-6"}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 7.5a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 21a7.5 7.5 0 0115 0" />
+    </svg>
+  )
+}

--- a/lms-frontend/src/components/BookForm.jsx
+++ b/lms-frontend/src/components/BookForm.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import api from '../api/axios'
+import Button from './ui/Button'
 
 export default function BookForm({ book, onSuccess, onCancel }) {
   const [form, setForm] = useState({
@@ -145,13 +146,13 @@ export default function BookForm({ book, onSuccess, onCancel }) {
         </div>
       )}
       <div className="flex gap-2">
-        <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+        <Button type="submit" className="bg-primary">
           Save
-        </button>
+        </Button>
         {onCancel && (
-          <button type="button" onClick={onCancel} className="border px-4 py-1 rounded">
+          <Button type="button" onClick={onCancel} className="border text-text">
             Cancel
-          </button>
+          </Button>
         )}
       </div>
     </form>

--- a/lms-frontend/src/components/MemberForm.jsx
+++ b/lms-frontend/src/components/MemberForm.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import api from '../api/axios'
+import Button from './ui/Button'
 
 export default function MemberForm({ member, onSuccess, onCancel }) {
   const [form, setForm] = useState({
@@ -108,13 +109,13 @@ export default function MemberForm({ member, onSuccess, onCancel }) {
         />
       </div>
       <div className="flex gap-2">
-        <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
+        <Button type="submit" className="bg-primary">
           Save
-        </button>
+        </Button>
         {onCancel && (
-          <button type="button" onClick={onCancel} className="border px-4 py-1 rounded">
+          <Button type="button" onClick={onCancel} className="border text-text">
             Cancel
-          </button>
+          </Button>
         )}
       </div>
     </form>

--- a/lms-frontend/src/components/Sidebar.jsx
+++ b/lms-frontend/src/components/Sidebar.jsx
@@ -3,10 +3,10 @@ import { getUserRole } from '../utils/auth'
 
 export default function Sidebar() {
   const linkClass = ({ isActive }) =>
-    `block px-4 py-2 hover:bg-gray-200 ${isActive ? 'font-bold' : ''}`
+    `block px-4 py-2 rounded hover:bg-primary/10 ${isActive ? 'font-bold' : ''}`
 
   return (
-    <aside className="w-48 bg-gray-100 min-h-screen">
+    <aside className="w-48 bg-background border-r min-h-screen">
       <nav className="p-4 space-y-2">
         <NavLink to="/dashboard" className={linkClass}>
           Dashboard

--- a/lms-frontend/src/components/ui/Button.jsx
+++ b/lms-frontend/src/components/ui/Button.jsx
@@ -1,0 +1,11 @@
+export default function Button({ as = 'button', children, className = '', ...props }) {
+  const Component = as
+  return (
+    <Component
+      className={`px-6 py-3 rounded-md font-semibold text-white transition-colors hover:opacity-90 active:opacity-80 ${className}`}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/lms-frontend/src/components/ui/Card.jsx
+++ b/lms-frontend/src/components/ui/Card.jsx
@@ -1,0 +1,5 @@
+export default function Card({ children, className = '' }) {
+  return (
+    <div className={`bg-white rounded-md shadow-md p-6 ${className}`}>{children}</div>
+  )
+}

--- a/lms-frontend/src/index.css
+++ b/lms-frontend/src/index.css
@@ -1,3 +1,4 @@
+@import './theme.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/lms-frontend/src/pages/BookListPage.jsx
+++ b/lms-frontend/src/pages/BookListPage.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
 import api from '../api/axios'
 import BookForm from '../components/BookForm'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import SearchIcon from '../assets/icons/SearchIcon'
+import BookIcon from '../assets/icons/BookIcon'
 
 export default function BookListPage() {
   const [books, setBooks] = useState([])
@@ -42,45 +46,43 @@ export default function BookListPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Books</h1>
-      <div className="mb-4 flex gap-2 items-center">
-        <form onSubmit={handleSearch} className="flex gap-2 flex-1">
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Books</h1>
+      <div className="flex flex-col gap-3">
+        <form onSubmit={handleSearch} className="flex flex-wrap gap-2">
           <input
             type="text"
             placeholder="Search by title"
             value={search.title}
             onChange={(e) => setSearch({ ...search, title: e.target.value })}
-            className="border p-1 flex-1"
+            className="border p-2 rounded flex-1 min-w-[150px]"
           />
           <input
             type="text"
             placeholder="Author"
             value={search.author}
             onChange={(e) => setSearch({ ...search, author: e.target.value })}
-            className="border p-1 flex-1"
+            className="border p-2 rounded flex-1 min-w-[150px]"
           />
           <input
             type="text"
             placeholder="Category"
             value={search.category}
             onChange={(e) => setSearch({ ...search, category: e.target.value })}
-            className="border p-1 flex-1"
+            className="border p-2 rounded flex-1 min-w-[150px]"
           />
-          <button
-            type="submit"
-            className="bg-blue-500 text-white px-4 py-1 rounded"
-          >
-            Search
-          </button>
+          <Button type="submit" className="bg-primary flex items-center gap-1">
+            <SearchIcon className="w-5 h-5" /> Search
+          </Button>
         </form>
-        <button
+        <Button
           type="button"
           onClick={() => setShowAdd((v) => !v)}
-          className="bg-green-500 text-white px-4 py-1 rounded"
+          className="bg-secondary w-fit"
         >
+          <BookIcon className="w-5 h-5 inline mr-1" />
           {showAdd ? 'Close' : 'Add Book'}
-        </button>
+        </Button>
       </div>
       {showAdd && (
         <div className="mb-4">
@@ -95,16 +97,17 @@ export default function BookListPage() {
       )}
       <ul className="space-y-2">
         {books.map((book) => (
-          <li key={book.bookId} className="border p-2 rounded">
-            <div className="flex justify-between items-center">
-              <span>{book.title}</span>
-              <button
-                className="text-blue-600 underline"
+          <li key={book.bookId}>
+            <Card className="flex justify-between items-start gap-2">
+              <span className="font-medium">{book.title}</span>
+              <Button
+                type="button"
                 onClick={() => setEditBook(book)}
+                className="bg-primary text-sm"
               >
                 Edit
-              </button>
-            </div>
+              </Button>
+            </Card>
             {editBook && editBook.bookId === book.bookId && (
               <div className="mt-2">
                 <BookForm

--- a/lms-frontend/src/pages/BorrowRecordPage.jsx
+++ b/lms-frontend/src/pages/BorrowRecordPage.jsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
 import api from '../api/axios'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import SearchIcon from '../assets/icons/SearchIcon'
+import BorrowIcon from '../assets/icons/BorrowIcon'
+import ReturnIcon from '../assets/icons/ReturnIcon'
 
 export default function BorrowRecordPage() {
   const [records, setRecords] = useState([])
@@ -72,71 +77,81 @@ export default function BorrowRecordPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Borrow Records</h1>
-      <form onSubmit={handleSearch} className="mb-4 flex gap-2">
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Borrow Records</h1>
+      <form onSubmit={handleSearch} className="flex gap-2 flex-wrap">
         <input
           type="text"
           placeholder="Title"
           value={search.title}
           onChange={(e) => setSearch({ ...search, title: e.target.value })}
-          className="border p-1"
+          className="border p-2 rounded"
         />
         <input
           type="date"
           value={search.startDate}
           onChange={(e) => setSearch({ ...search, startDate: e.target.value })}
-          className="border p-1"
+          className="border p-2 rounded"
         />
         <input
           type="date"
           value={search.endDate}
           onChange={(e) => setSearch({ ...search, endDate: e.target.value })}
-          className="border p-1"
+          className="border p-2 rounded"
         />
-        <button type="submit" className="bg-blue-500 text-white px-4 rounded">
-          Search
-        </button>
+        <Button type="submit" className="bg-primary flex items-center gap-1">
+          <SearchIcon className="w-5 h-5" /> Search
+        </Button>
       </form>
-      <form onSubmit={handleBorrow} className="mb-4 flex gap-2">
+      <form onSubmit={handleBorrow} className="flex gap-2 flex-wrap">
         <input
           type="number"
           placeholder="Member ID"
           value={memberId}
           onChange={(e) => setMemberId(e.target.value)}
-          className="border p-1"
+          className="border p-2 rounded"
         />
         <input
           type="number"
           placeholder="Book ID"
           value={bookId}
           onChange={(e) => setBookId(e.target.value)}
-          className="border p-1"
+          className="border p-2 rounded"
         />
-        <button type="submit" className="bg-blue-500 text-white px-4 rounded">
-          Borrow
-        </button>
+        <Button type="submit" className="bg-secondary flex items-center gap-1">
+          <BorrowIcon className="w-5 h-5" /> Borrow
+        </Button>
       </form>
       <ul className="space-y-2">
         {records.map((r) => {
           const overdue = r.returnDate == null && new Date(r.dueDate) < new Date()
           return (
-            <li key={r.recordId} className="border p-2 rounded flex justify-between items-center">
-              <span>
-                Record {r.recordId} &ndash; Book {r.bookId} &ndash; Member {r.memberId}
-                <span className="ml-2">Due: {r.dueDate}</span>
-                {overdue && <span className="text-red-600 ml-2">Overdue!</span>}
-              </span>
-              {r.returnDate == null && (
-                <div className="flex gap-2">
-                  <button onClick={() => handleReturn(r.recordId)} className="text-red-500">
-                    Return
-                  </button>
-                  <button onClick={() => handleRenew(r.recordId)} className="text-blue-600">
-                    Renew
-                  </button>
-                </div>
-              )}
+            <li key={r.recordId}>
+              <Card className="flex justify-between items-center gap-2">
+                <span className="flex-1">
+                  Record {r.recordId} &ndash; Book {r.bookId} &ndash; Member {r.memberId}
+                  <span className="ml-2">Due: {r.dueDate}</span>
+                  {overdue && <span className="text-red-600 ml-2">Overdue!</span>}
+                </span>
+                {r.returnDate == null && (
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      onClick={() => handleReturn(r.recordId)}
+                      className="bg-primary text-xs"
+                    >
+                      <ReturnIcon className="w-4 h-4 mr-1" /> Return
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => handleRenew(r.recordId)}
+                      className="bg-secondary text-xs"
+                    >
+                      Renew
+                    </Button>
+                  </div>
+                )}
+              </Card>
             </li>
           )
         })}

--- a/lms-frontend/src/pages/Dashboard.jsx
+++ b/lms-frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,8 @@
 import { useState } from 'react'
 import api from '../api/axios'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import FineIcon from '../assets/icons/FineIcon'
 
 export default function Dashboard() {
   const [memberId, setMemberId] = useState('')
@@ -17,25 +20,24 @@ export default function Dashboard() {
   }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <div className="mb-4 flex gap-2 items-center">
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <Card className="flex items-center gap-2 w-fit">
         <input
           type="number"
           placeholder="Member ID"
           value={memberId}
           onChange={(e) => setMemberId(e.target.value)}
-          className="border p-1"
+          className="border p-2 rounded"
         />
-        <button
-          onClick={fetchFine}
-          className="bg-blue-500 text-white px-4 py-1 rounded"
-        >
-          Check Fines
-        </button>
-      </div>
+        <Button onClick={fetchFine} className="bg-primary">
+          <FineIcon className="w-5 h-5 inline mr-1" /> Check Fines
+        </Button>
+      </Card>
       {fine !== null && (
-        <div className="text-lg">Outstanding Fines: ${fine.toFixed(2)}</div>
+        <div className="text-lg font-medium">
+          Outstanding Fines: ${fine.toFixed(2)}
+        </div>
       )}
     </div>
   )

--- a/lms-frontend/src/pages/HomePage.jsx
+++ b/lms-frontend/src/pages/HomePage.jsx
@@ -1,4 +1,9 @@
 import { Link } from 'react-router-dom'
+import Button from '../components/ui/Button'
+import BookIcon from '../assets/icons/BookIcon'
+import UserIcon from '../assets/icons/UserIcon'
+import RecordIcon from '../assets/icons/RecordIcon'
+import Card from '../components/ui/Card'
 
 export default function HomePage() {
   return (
@@ -6,74 +11,51 @@ export default function HomePage() {
       {/* Hero Section */}
       <header
         className="relative h-96 bg-center bg-cover"
-        style={{
-          backgroundImage:
-            "url('https://source.unsplash.com/1600x900/?library')",
-        }}
+        style={{ backgroundImage: "url('https://source.unsplash.com/1600x900/?library')" }}
       >
-        <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center text-white text-center px-4">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Welcome to Our Library
-          </h1>
+        <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/20 flex flex-col items-center justify-center text-white text-center px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Welcome to Our Library</h1>
           <p className="mb-6 text-lg md:text-xl max-w-2xl">
-            Explore, manage and borrow books with ease through our Library
-            Management System.
+            Explore, manage and borrow books with ease through our Library Management System.
           </p>
           <div className="flex gap-4">
-            <Link
-              to="/login"
-              className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded"
-            >
+            <Button as={Link} to="/login" className="bg-primary">
               Login
-            </Link>
-            <Link
-              to="/register"
-              className="bg-green-500 hover:bg-green-600 text-white px-6 py-3 rounded"
-            >
+            </Button>
+            <Button as={Link} to="/register" className="bg-secondary">
               Register
-            </Link>
+            </Button>
           </div>
         </div>
       </header>
 
       {/* Features Section */}
-      <section className="flex-1 py-12 px-4 bg-gray-50">
+      <section className="flex-1 py-12 px-4 bg-background">
         <h2 className="text-3xl font-bold text-center mb-8">Features</h2>
         <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
-          <div className="bg-white p-6 rounded shadow">
-            <h3 className="text-xl font-semibold mb-2">
-              Book Search and Borrowing
-            </h3>
-            <p className="text-gray-600">
-              Find the books you need quickly and check them out effortlessly.
-            </p>
-          </div>
-          <div className="bg-white p-6 rounded shadow">
-            <h3 className="text-xl font-semibold mb-2">Member Management</h3>
-            <p className="text-gray-600">
-              Manage library members, their information and privileges with
-              ease.
-            </p>
-          </div>
-          <div className="bg-white p-6 rounded shadow">
-            <h3 className="text-xl font-semibold mb-2">
-              Borrowing Records Tracking
-            </h3>
-            <p className="text-gray-600">
-              Keep track of borrowed books and due dates in one convenient
-              place.
-            </p>
-          </div>
+          <Card className="text-center space-y-2">
+            <BookIcon className="w-10 h-10 mx-auto text-primary" />
+            <h3 className="text-xl font-semibold">Book Search and Borrowing</h3>
+            <p className="text-gray-600">Find books quickly and check them out effortlessly.</p>
+          </Card>
+          <Card className="text-center space-y-2">
+            <UserIcon className="w-10 h-10 mx-auto text-primary" />
+            <h3 className="text-xl font-semibold">Member Management</h3>
+            <p className="text-gray-600">Manage library members and privileges with ease.</p>
+          </Card>
+          <Card className="text-center space-y-2">
+            <RecordIcon className="w-10 h-10 mx-auto text-primary" />
+            <h3 className="text-xl font-semibold">Borrowing Records Tracking</h3>
+            <p className="text-gray-600">Keep track of borrowed books and due dates in one place.</p>
+          </Card>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="bg-gray-800 text-white text-center py-4">
+      <footer className="bg-primary text-white text-center py-4 mt-auto">
         <div className="font-semibold">Library Management System</div>
         <div>contact@library.com</div>
-        <div className="text-sm mt-1">
-          &copy; {new Date().getFullYear()} Library
-        </div>
+        <div className="text-sm mt-1">&copy; {new Date().getFullYear()} Library</div>
       </footer>
     </div>
   )

--- a/lms-frontend/src/pages/LoginPage.jsx
+++ b/lms-frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import api from '../api/axios'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import UserIcon from '../assets/icons/UserIcon'
 
 export default function LoginPage() {
   const [username, setUsername] = useState('')
@@ -20,43 +23,52 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex items-center justify-center h-screen bg-gray-50">
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-6 rounded shadow w-80"
-      >
-        <h2 className="text-xl mb-4 font-bold text-center">Login</h2>
-        <div className="mb-2">
-          <input
-            type="text"
-            placeholder="Username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            className="w-full border px-2 py-1"
-          />
-        </div>
-        <div className="mb-4">
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full border px-2 py-1"
-          />
-        </div>
-        <button
-          type="submit"
-          className="w-full bg-blue-500 text-white py-1 rounded"
-        >
+    <div className="flex items-center justify-center min-h-screen bg-background p-4">
+      {/* ⬆️ Improved: card container with theming */}
+      <Card className="w-full max-w-sm space-y-4">
+        <h2 className="text-2xl font-bold text-center flex items-center justify-center gap-2">
+          {/* ⬆️ Improved: added user icon */}
+          <UserIcon className="w-8 h-8 text-primary" />
           Login
-        </button>
-        <div className="mt-2 text-center">
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="sr-only" htmlFor="username">
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="border p-2 rounded w-full"
+            />
+          </div>
+          <div>
+            <label className="sr-only" htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="border p-2 rounded w-full"
+            />
+          </div>
+          <Button type="submit" className="bg-primary w-full">
+            Login
+          </Button>
+        </form>
+        <div className="text-center">
           <span className="text-sm">Don't have an account? </span>
-          <Link to="/register" className="text-blue-600 underline">
+          <Link to="/register" className="text-primary underline">
             Register
           </Link>
         </div>
-      </form>
+      </Card>
     </div>
   )
 }

--- a/lms-frontend/src/pages/MemberListPage.jsx
+++ b/lms-frontend/src/pages/MemberListPage.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
 import api from '../api/axios'
 import MemberForm from '../components/MemberForm'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import SearchIcon from '../assets/icons/SearchIcon'
+import UserIcon from '../assets/icons/UserIcon'
 
 export default function MemberListPage() {
   const [members, setMembers] = useState([])
@@ -34,51 +38,62 @@ export default function MemberListPage() {
   }, [])
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Members</h1>
-      <div className="mb-4 flex gap-2 items-center">
-        <form onSubmit={handleSearch} className="flex gap-2 flex-1">
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Members</h1>
+      <div className="flex flex-col gap-3">
+        <form onSubmit={handleSearch} className="flex gap-2 flex-wrap">
           <input
             type="text"
             placeholder="Search by name"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="border p-1 flex-1"
+            className="border p-2 rounded flex-1 min-w-[150px]"
           />
-          <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">
-            Search
-          </button>
+          <Button type="submit" className="bg-primary flex items-center gap-1">
+            <SearchIcon className="w-5 h-5" /> Search
+          </Button>
         </form>
-        <button
+        <Button
           type="button"
           onClick={() => setShowAdd((v) => !v)}
-          className="bg-green-500 text-white px-4 py-1 rounded"
+          className="bg-secondary w-fit"
         >
+          <UserIcon className="w-5 h-5 inline mr-1" />
           {showAdd ? 'Close' : 'Add Member'}
-        </button>
+        </Button>
       </div>
       {showAdd && (
         <div className="mb-4">
-          <MemberForm onSuccess={() => { setShowAdd(false); fetchMembers(); }} onCancel={() => setShowAdd(false)} />
+          <MemberForm
+            onSuccess={() => {
+              setShowAdd(false)
+              fetchMembers()
+            }}
+            onCancel={() => setShowAdd(false)}
+          />
         </div>
       )}
       <ul className="space-y-2">
         {members.map((m) => (
-          <li key={m.memberId} className="border p-2 rounded">
-            <div className="flex justify-between items-center">
-              <span>{m.fullName}</span>
-              <button
-                className="text-blue-600 underline"
+          <li key={m.memberId}>
+            <Card className="flex justify-between items-start gap-2">
+              <span className="font-medium">{m.fullName}</span>
+              <Button
+                type="button"
                 onClick={() => setEditMember(m)}
+                className="bg-primary text-sm"
               >
                 Edit
-              </button>
-            </div>
+              </Button>
+            </Card>
             {editMember && editMember.memberId === m.memberId && (
               <div className="mt-2">
                 <MemberForm
                   member={editMember}
-                  onSuccess={() => { setEditMember(null); fetchMembers(); }}
+                  onSuccess={() => {
+                    setEditMember(null)
+                    fetchMembers()
+                  }}
                   onCancel={() => setEditMember(null)}
                 />
               </div>

--- a/lms-frontend/src/pages/RegisterPage.jsx
+++ b/lms-frontend/src/pages/RegisterPage.jsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import api from '../api/axios'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import UserIcon from '../assets/icons/UserIcon'
 
 export default function RegisterPage() {
   const [form, setForm] = useState({
@@ -40,77 +43,76 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-6 rounded shadow w-80 space-y-2"
-      >
-        <h2 className="text-xl mb-2 font-bold text-center">Register</h2>
-        <input
-          type="text"
-          name="username"
-          placeholder="Username"
-          value={form.username}
-          onChange={handleChange}
-          className="border p-1 w-full"
-          required
-        />
-        <input
-          type="password"
-          name="password"
-          placeholder="Password"
-          value={form.password}
-          onChange={handleChange}
-          className="border p-1 w-full"
-          required
-        />
-        <input
-          type="text"
-          name="fullName"
-          placeholder="Full Name"
-          value={form.fullName}
-          onChange={handleChange}
-          className="border p-1 w-full"
-        />
-        <input
-          type="text"
-          name="contactInfo"
-          placeholder="Contact Info"
-          value={form.contactInfo}
-          onChange={handleChange}
-          className="border p-1 w-full"
-        />
-        <input
-          type="text"
-          name="address"
-          placeholder="Address"
-          value={form.address}
-          onChange={handleChange}
-          className="border p-1 w-full"
-        />
-        <input
-          type="date"
-          name="membershipStart"
-          placeholder="Start"
-          value={form.membershipStart}
-          onChange={handleChange}
-          className="border p-1 w-full"
-        />
-        <input
-          type="date"
-          name="membershipEnd"
-          placeholder="End"
-          value={form.membershipEnd}
-          onChange={handleChange}
-          className="border p-1 w-full"
-        />
-        <button
-          type="submit"
-          className="w-full bg-blue-500 text-white py-1 rounded"
-        >
-          Register
-        </button>
-      </form>
+    <div className="flex items-center justify-center min-h-screen bg-background p-4">
+      {/* ⬆️ Improved: theme card layout */}
+      <Card className="w-full max-w-sm space-y-4">
+        <h2 className="text-2xl font-bold text-center flex items-center justify-center gap-2">
+          <UserIcon className="w-8 h-8 text-primary" /> Register
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="text"
+            name="username"
+            placeholder="Username"
+            value={form.username}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+            required
+          />
+          <input
+            type="password"
+            name="password"
+            placeholder="Password"
+            value={form.password}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+            required
+          />
+          <input
+            type="text"
+            name="fullName"
+            placeholder="Full Name"
+            value={form.fullName}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+          />
+          <input
+            type="text"
+            name="contactInfo"
+            placeholder="Contact Info"
+            value={form.contactInfo}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+          />
+          <input
+            type="text"
+            name="address"
+            placeholder="Address"
+            value={form.address}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+          />
+          <input
+            type="date"
+            name="membershipStart"
+            placeholder="Start"
+            value={form.membershipStart}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+          />
+          <input
+            type="date"
+            name="membershipEnd"
+            placeholder="End"
+            value={form.membershipEnd}
+            onChange={handleChange}
+            className="border p-2 rounded w-full"
+          />
+          <Button type="submit" className="bg-secondary w-full">
+            Register
+          </Button>
+        </form>
+      </Card>
     </div>
   )
 }

--- a/lms-frontend/src/pages/ReservationPage.jsx
+++ b/lms-frontend/src/pages/ReservationPage.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react'
 import api from '../api/axios'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import BorrowIcon from '../assets/icons/BorrowIcon'
+import ReturnIcon from '../assets/icons/ReturnIcon'
 
 export default function ReservationPage() {
   const [reservations, setReservations] = useState([])
@@ -43,41 +47,44 @@ export default function ReservationPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Reservations</h1>
-      <form onSubmit={handleReserve} className="mb-4 flex gap-2">
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Reservations</h1>
+      <form onSubmit={handleReserve} className="flex gap-2 flex-wrap">
         <input
           type="number"
           placeholder="Member ID"
           value={memberId}
           onChange={(e) => setMemberId(e.target.value)}
-          className="border p-1"
+          className="border p-2 rounded"
         />
         <input
           type="number"
           placeholder="Book ID"
           value={bookId}
           onChange={(e) => setBookId(e.target.value)}
-          className="border p-1"
+          className="border p-2 rounded"
         />
-        <button type="submit" className="bg-blue-500 text-white px-4 rounded">
-          Reserve
-        </button>
+        <Button type="submit" className="bg-primary flex items-center gap-1">
+          <BorrowIcon className="w-5 h-5" /> Reserve
+        </Button>
       </form>
       <ul className="space-y-2">
         {reservations.map((r) => (
-          <li key={r.reservationId} className="border p-2 rounded flex justify-between items-center">
-            <span>
-              Member {r.memberId} reserved Book {r.bookId} ({r.status})
-            </span>
-            {r.status === 'ACTIVE' && (
-              <button
-                onClick={() => handleCancel(r.reservationId)}
-                className="text-red-500"
-              >
-                Cancel
-              </button>
-            )}
+          <li key={r.reservationId}>
+            <Card className="flex justify-between items-center gap-2">
+              <span>
+                Member {r.memberId} reserved Book {r.bookId} ({r.status})
+              </span>
+              {r.status === 'ACTIVE' && (
+                <Button
+                  type="button"
+                  onClick={() => handleCancel(r.reservationId)}
+                  className="bg-secondary text-xs"
+                >
+                  <ReturnIcon className="w-4 h-4 mr-1" /> Cancel
+                </Button>
+              )}
+            </Card>
           </li>
         ))}
       </ul>

--- a/lms-frontend/src/theme.css
+++ b/lms-frontend/src/theme.css
@@ -1,0 +1,14 @@
+:root {
+  --color-primary: #2563eb;
+  --color-secondary: #16a34a;
+  --color-background: #f8fafc;
+  --color-text: #1e293b;
+  --font-base: 'Inter', sans-serif;
+  --radius: 0.5rem;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-base);
+}

--- a/lms-frontend/tailwind.config.js
+++ b/lms-frontend/tailwind.config.js
@@ -2,7 +2,20 @@
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: 'var(--color-primary)',
+        secondary: 'var(--color-secondary)',
+        background: 'var(--color-background)',
+        text: 'var(--color-text)',
+      },
+      fontFamily: {
+        base: 'var(--font-base)',
+      },
+      borderRadius: {
+        DEFAULT: 'var(--radius)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add design tokens via `theme.css`
- extend tailwind to reference CSS variables
- import theme in global styles
- introduce reusable `Button` and `Card` UI components
- add inline SVG icons (book, user, record, search)
- redesign `HomePage` with modern layout and icons
- beautify remaining pages with theme components and new SVG icons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b45e6ed508330930cfaee4a758acf