### PR TITLE
Add book search on homepage

### DIFF
--- a/lms-frontend/src/App.jsx
+++ b/lms-frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
 import HomePage from './pages/HomePage'
+import BookDetailPage from './pages/BookDetailPage'
 import BookListPage from './pages/BookListPage'
 import MemberListPage from './pages/MemberListPage'
 import BorrowRecordPage from './pages/BorrowRecordPage'
@@ -16,6 +17,7 @@ export default function App() {
     <Router>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/book/:id" element={<BookDetailPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route

--- a/lms-frontend/src/pages/BookDetailPage.jsx
+++ b/lms-frontend/src/pages/BookDetailPage.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import api from '../api/axios'
+import Card from '../components/ui/Card'
+
+export default function BookDetailPage() {
+  const { id } = useParams()
+  const [book, setBook] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchBook = async () => {
+      try {
+        const { data } = await api.get(`/books/${id}`)
+        setBook(data)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchBook()
+  }, [id])
+
+  if (loading) return <div className="p-4">Loading...</div>
+  if (!book) return <div className="p-4">Book not found</div>
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">{book.title}</h1>
+      <p className="text-gray-600">by {book.author}</p>
+      <Card className="space-y-1">
+        <p>
+          <strong>ISBN:</strong> {book.isbn}
+        </p>
+        <p>
+          <strong>Category:</strong> {book.category}
+        </p>
+        <p>
+          <strong>Publication Year:</strong> {book.publicationYear}
+        </p>
+        <p>
+          <strong>Status:</strong> {book.status}
+        </p>
+        <p>
+          <strong>Copies Available:</strong> {book.copiesAvailable}
+        </p>
+      </Card>
+    </div>
+  )
+}

--- a/lms-frontend/src/pages/HomePage.jsx
+++ b/lms-frontend/src/pages/HomePage.jsx
@@ -1,11 +1,35 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
+import api from '../api/axios'
 import Button from '../components/ui/Button'
 import BookIcon from '../assets/icons/BookIcon'
 import UserIcon from '../assets/icons/UserIcon'
 import RecordIcon from '../assets/icons/RecordIcon'
+import SearchIcon from '../assets/icons/SearchIcon'
 import Card from '../components/ui/Card'
 
 export default function HomePage() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [searched, setSearched] = useState(false)
+
+  const handleSearch = async (e) => {
+    e.preventDefault()
+    if (!query.trim()) return
+    setLoading(true)
+    setSearched(true)
+    try {
+      // 🔍 Fetch books by title from backend
+      const { data } = await api.get('/books', { params: { title: query } })
+      setResults(data)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
     <div className="flex flex-col min-h-screen">
       {/* Hero Section */}
@@ -27,9 +51,54 @@ export default function HomePage() {
             </Button>
           </div>
         </div>
-      </header>
+        </header>
 
-      {/* Features Section */}
+        {/* 🔍 Search bar for books */}
+        <section className="bg-background py-8 px-4">
+          <form
+            onSubmit={handleSearch}
+            className="max-w-xl mx-auto flex w-full border rounded-md overflow-hidden"
+          >
+            <input
+              type="text"
+              placeholder="Search books by title"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="flex-1 p-3 outline-none"
+            />
+            <button
+              type="submit"
+              className="bg-primary text-white px-4 flex items-center justify-center"
+            >
+              <SearchIcon className="w-5 h-5 mr-1" />
+              Search
+            </button>
+          </form>
+
+          {/* 🧠 Render results dynamically from backend */}
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {loading && <div className="text-center col-span-full">Loading...</div>}
+            {!loading && searched && results.length === 0 && (
+              <div className="text-center col-span-full text-gray-500">No books found</div>
+            )}
+            {!loading &&
+              results.map((book) => (
+                <Link key={book.bookId} to={`/book/${book.bookId}`}> {/* 🔗 Each result links to BookDetailPage */}
+                  <Card className="cursor-pointer h-full hover:shadow-lg transition">
+                    <h3 className="font-semibold text-lg">{book.title}</h3>
+                    <p className="text-sm text-gray-600">by {book.author}</p>
+                    <p className="text-xs mt-1">
+                      {book.copiesAvailable > 0
+                        ? `${book.copiesAvailable} copies available`
+                        : 'Unavailable'}
+                    </p>
+                  </Card>
+                </Link>
+              ))}
+          </div>
+        </section>
+
+        {/* Features Section */}
       <section className="flex-1 py-12 px-4 bg-background">
         <h2 className="text-3xl font-bold text-center mb-8">Features</h2>
         <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">


### PR DESCRIPTION
## Summary
- implement book search bar on the homepage with dynamic results
- create `BookDetailPage` to show single book details
- hook up `/book/:id` route in the router

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b4a5c753c83308fab57de62289789