### PR TITLE
Add logout button in Sidebar

### DIFF
--- a/lms-frontend/src/components/Sidebar.jsx
+++ b/lms-frontend/src/components/Sidebar.jsx
@@ -1,14 +1,20 @@
-import { NavLink } from 'react-router-dom'
-import { getUserRole } from '../utils/auth'
+import { NavLink, useNavigate } from 'react-router-dom'
+import { getUserRole, logout } from '../utils/auth'
 import Logo from './common/Logo'
 
 export default function Sidebar() {
+  const navigate = useNavigate()
   const linkClass = ({ isActive }) =>
     `block px-4 py-2 rounded hover:bg-primary/10 ${isActive ? 'font-bold' : ''}`
 
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+
   return (
-    <aside className="w-48 bg-background border-r min-h-screen">
-      <nav className="p-4 space-y-2">
+    <aside className="w-48 bg-background border-r min-h-screen flex flex-col">
+      <nav className="p-4 space-y-2 flex-1">
         {/* ✅ Logo added to sidebar */}
         <Logo size="small" variant="navbar" />
         <NavLink to="/dashboard" className={linkClass}>
@@ -31,6 +37,12 @@ export default function Sidebar() {
           Reservations
         </NavLink>
       </nav>
+      <button
+        onClick={handleLogout}
+        className="m-4 block px-4 py-2 rounded hover:bg-primary/10 text-left"
+      >
+        Logout
+      </button>
     </aside>
   )
 }

--- a/lms-frontend/src/utils/auth.js
+++ b/lms-frontend/src/utils/auth.js
@@ -8,3 +8,7 @@ export function getUserRole() {
     return null
   }
 }
+
+export function logout() {
+  localStorage.removeItem('token')
+}


### PR DESCRIPTION
## Summary
- add `logout()` helper to remove token
- place Logout button at the bottom of the sidebar
- wire button to clear storage and navigate to login

## Testing
- `npm run lint`
- `mvn test` *(fails: Could not resolve Spring Boot parent due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687b5134818c8330bb81589fb009538a