### PR TITLE
Add current member endpoint and auto member ID

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 
@@ -75,5 +76,14 @@ public class MemberController {
         }
         memberRepository.deleteById(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberDto> getMyMember(
+            @AuthenticationPrincipal(expression = "username") String username) {
+        return memberRepository
+                .findByUser_Username(username)
+                .map(member -> ResponseEntity.ok(MemberDto.fromEntity(member)))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
 }

--- a/lms-frontend/src/pages/BorrowRecordPage.jsx
+++ b/lms-frontend/src/pages/BorrowRecordPage.jsx
@@ -8,7 +8,7 @@ import ReturnIcon from '../assets/icons/ReturnIcon'
 
 export default function BorrowRecordPage() {
   const [records, setRecords] = useState([])
-  const [memberId, setMemberId] = useState('')
+  const [memberId, setMemberId] = useState(null)
   const [bookId, setBookId] = useState('')
   const [search, setSearch] = useState({ title: '', startDate: '', endDate: '' })
 
@@ -23,6 +23,15 @@ export default function BorrowRecordPage() {
 
   useEffect(() => {
     fetchRecords()
+    const fetchMember = async () => {
+      try {
+        const { data } = await api.get('/members/me')
+        setMemberId(data.memberId)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchMember()
   }, [])
 
   const handleBorrow = async (e) => {
@@ -31,7 +40,6 @@ export default function BorrowRecordPage() {
       await api.post('/borrow-records/borrow', null, {
         params: { memberId, bookId },
       })
-      setMemberId('')
       setBookId('')
       fetchRecords()
     } catch (err) {
@@ -104,13 +112,6 @@ export default function BorrowRecordPage() {
         </Button>
       </form>
       <form onSubmit={handleBorrow} className="flex gap-2 flex-wrap">
-        <input
-          type="number"
-          placeholder="Member ID"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="border p-2 rounded"
-        />
         <input
           type="number"
           placeholder="Book ID"

--- a/lms-frontend/src/pages/ReservationPage.jsx
+++ b/lms-frontend/src/pages/ReservationPage.jsx
@@ -7,7 +7,7 @@ import ReturnIcon from '../assets/icons/ReturnIcon'
 
 export default function ReservationPage() {
   const [reservations, setReservations] = useState([])
-  const [memberId, setMemberId] = useState('')
+  const [memberId, setMemberId] = useState(null)
   const [bookId, setBookId] = useState('')
 
   const fetchReservations = async () => {
@@ -21,13 +21,21 @@ export default function ReservationPage() {
 
   useEffect(() => {
     fetchReservations()
+    const fetchMember = async () => {
+      try {
+        const { data } = await api.get('/members/me')
+        setMemberId(data.memberId)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchMember()
   }, [])
 
   const handleReserve = async (e) => {
     e.preventDefault()
     try {
       await api.post('/reservations', null, { params: { memberId, bookId } })
-      setMemberId('')
       setBookId('')
       fetchReservations()
     } catch (err) {
@@ -50,13 +58,6 @@ export default function ReservationPage() {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Reservations</h1>
       <form onSubmit={handleReserve} className="flex gap-2 flex-wrap">
-        <input
-          type="number"
-          placeholder="Member ID"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="border p-2 rounded"
-        />
         <input
           type="number"
           placeholder="Book ID"


### PR DESCRIPTION
## Summary
- add `getMyMember` endpoint for signed-in user
- auto-populate member ID on BorrowRecord and Reservation pages

## Testing
- `mvn test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b524b3b80833085916a1a1da3c936