### PR TITLE
Display username in sidebar

### DIFF
--- a/lms-frontend/src/components/Sidebar.jsx
+++ b/lms-frontend/src/components/Sidebar.jsx
@@ -1,9 +1,11 @@
 import { NavLink, useNavigate } from 'react-router-dom'
-import { getUserRole, logout } from '../utils/auth'
+import { getUserRole, getUsername, logout } from '../utils/auth'
 import Logo from './common/Logo'
 
 export default function Sidebar() {
   const navigate = useNavigate()
+  const role = getUserRole()
+  const username = getUsername()
   const linkClass = ({ isActive }) =>
     `block px-4 py-2 rounded hover:bg-primary/10 ${isActive ? 'font-bold' : ''}`
 
@@ -17,10 +19,15 @@ export default function Sidebar() {
       <nav className="p-4 space-y-2 flex-1">
         {/* ✅ Logo added to sidebar */}
         <Logo size="small" variant="navbar" />
+        {username && (
+          <div className="text-xs text-gray-500 px-1">
+            {username} ({role})
+          </div>
+        )}
         <NavLink to="/dashboard" className={linkClass}>
           Dashboard
         </NavLink>
-        {getUserRole() === 'ADMIN' && (
+        {role === 'ADMIN' && (
           <>
             <NavLink to="/books" className={linkClass}>
               Books

--- a/lms-frontend/src/utils/auth.js
+++ b/lms-frontend/src/utils/auth.js
@@ -9,6 +9,17 @@ export function getUserRole() {
   }
 }
 
+export function getUsername() {
+  const token = localStorage.getItem('token')
+  if (!token) return null
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    return payload.sub || payload.username || null
+  } catch {
+    return null
+  }
+}
+
 export function logout() {
   localStorage.removeItem('token')
 }


### PR DESCRIPTION
## Summary
- add helper to decode username from JWT
- show signed-in user info in Sidebar

## Testing
- `npm run lint`
- `npm run build`
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b53588fd88330b15442a0354193df