### PR TITLE
Fix loadUserData missing in HomePage

### DIFF
--- a/lms-frontend/src/pages/HomePage.jsx
+++ b/lms-frontend/src/pages/HomePage.jsx
@@ -20,6 +20,18 @@ export default function HomePage() {
   const [memberId, setMemberId] = useState(null)
   const [records, setRecords] = useState([])
 
+  const loadUserData = useCallback(async () => {
+    const token = localStorage.getItem('token')
+    if (!token) return
+    try {
+      const { data: member } = await api.get('/members/me')
+      setMemberId(member.memberId)
+      const res = await api.get('/borrow-records/my')
+      setRecords(res.data || [])
+    } catch (err) {
+      console.error(err)
+    }
+  }, [])
 
   const fetchResults = useCallback(async () => {
     if (!query.trim()) return


### PR DESCRIPTION
## Summary
- restore `loadUserData` function on HomePage to fetch current member and borrow record info

## Testing
- `./mvnw test` *(fails: Could not resolve dependencies)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687b7c8af8fc8330a5802a843f7aeb11