### PR TITLE
Fix role case handling in dashboard layout

### DIFF
--- a/lms-frontend/src/components/TabNav.jsx
+++ b/lms-frontend/src/components/TabNav.jsx
@@ -8,7 +8,7 @@ import SearchIcon from '../assets/icons/SearchIcon'
 import FineIcon from '../assets/icons/FineIcon'
 
 export default function TabNav({ role }) {
-  const userRole = role || getUserRole()
+  const userRole = (role || getUserRole() || '').toUpperCase()
   const linkClass = ({ isActive }) =>
     `flex items-center gap-1 px-3 py-2 border-b-2 hover:text-primary ${
       isActive

--- a/lms-frontend/src/layouts/DashboardLayout.jsx
+++ b/lms-frontend/src/layouts/DashboardLayout.jsx
@@ -4,7 +4,7 @@ import TabNav from '../components/TabNav'
 import Header from '../components/Header'
 
 export default function DashboardLayout({ role }) {
-  const userRole = (role || getUserRole() || '').toLowerCase()
+  const userRole = role || getUserRole() || ''
   return (
     <div className="min-h-screen flex flex-col">
       {/* ✅ New shared header with logo and logout */}


### PR DESCRIPTION
## Summary
- preserve original role casing in `DashboardLayout`
- normalize role casing in `TabNav` so ADMIN is matched correctly

## Testing
- `npm run lint`
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687c4c1bde9883309c4d694e002e12c6