### PR TITLE
Add role-based redirects for auth pages

### DIFF
--- a/lms-frontend/src/pages/LoginPage.jsx
+++ b/lms-frontend/src/pages/LoginPage.jsx
@@ -5,6 +5,7 @@ import Button from '../components/ui/Button'
 import Card from '../components/ui/Card'
 import UserIcon from '../assets/icons/UserIcon'
 import Logo from '../components/common/Logo'
+import { getUserRole } from '../utils/auth'
 
 export default function LoginPage() {
   const [username, setUsername] = useState('')
@@ -16,7 +17,12 @@ export default function LoginPage() {
     try {
       const { data } = await api.post('/auth/login', { username, password })
       localStorage.setItem('token', data.token)
-      navigate('/dashboard')
+      const role = getUserRole()
+      if (role === 'ADMIN') {
+        navigate('/admin-dashboard')
+      } else {
+        navigate('/dashboard')
+      }
     } catch (err) {
       console.error(err)
       alert('Login failed')

--- a/lms-frontend/src/pages/RegisterPage.jsx
+++ b/lms-frontend/src/pages/RegisterPage.jsx
@@ -5,6 +5,7 @@ import Button from '../components/ui/Button'
 import Card from '../components/ui/Card'
 import UserIcon from '../assets/icons/UserIcon'
 import Logo from '../components/common/Logo'
+import { getUserRole } from '../utils/auth'
 
 export default function RegisterPage() {
   const [form, setForm] = useState({
@@ -36,7 +37,12 @@ export default function RegisterPage() {
         membershipEnd: form.membershipEnd,
       })
       localStorage.setItem('token', data.token)
-      navigate('/dashboard')
+      const role = getUserRole()
+      if (role === 'ADMIN') {
+        navigate('/admin-dashboard')
+      } else {
+        navigate('/dashboard')
+      }
     } catch (err) {
       console.error(err)
       alert('Registration failed')


### PR DESCRIPTION
## Summary
- decode stored JWT after login and registration
- redirect admins to `/admin-dashboard`
- keep members on `/dashboard`

## Testing
- `./mvnw -q test` *(fails: Could not resolve Spring Boot parent POM)*
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687c503d63888330a981aec20eb60aa8