### PR TITLE
Add configurable link to Logo component

### DIFF
--- a/lms-frontend/src/components/Header.jsx
+++ b/lms-frontend/src/components/Header.jsx
@@ -7,6 +7,7 @@ export default function Header() {
   const navigate = useNavigate()
   const username = getUsername()
   const role = getUserRole()
+  const logoDestination = role === 'ADMIN' ? '/admin-dashboard' : '/dashboard'
 
   const handleLogout = () => {
     // ✅ Clear token and redirect on logout
@@ -18,7 +19,7 @@ export default function Header() {
     // 🧠 Top navigation bar shown after login
     <header className="bg-white border-b flex items-center justify-between px-4 py-2">
       {/* Logo navigates to dashboard */}
-      <Logo size="small" variant="navbar" />
+      <Logo size="small" variant="navbar" to={logoDestination} />
       <div className="flex items-center gap-3">
         {/* 🧠 Displaying user role and name in top right */}
         {username && (

--- a/lms-frontend/src/components/common/Logo.jsx
+++ b/lms-frontend/src/components/common/Logo.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 
-export default function Logo({ size = 'medium', variant = 'navbar' }) {
+// Added optional `to` prop so logo link can be customized
+export default function Logo({ size = 'medium', variant = 'navbar', to = '/' }) {
   const sizeClasses = {
     small: 'w-8',
     medium: 'w-16',
@@ -18,7 +19,7 @@ export default function Logo({ size = 'medium', variant = 'navbar' }) {
 
   return (
     // 📌 Reusable logo for all pages
-    <Link to="/" className={variant === 'navbar' ? 'block' : undefined}>
+    <Link to={to} className={variant === 'navbar' ? 'block' : undefined}>
       <img
         src="/logo.png"
         alt="Library Logo"


### PR DESCRIPTION
## Summary
- allow `Logo` to accept an optional `to` prop
- route header logo to the correct dashboard depending on role

## Testing
- `./mvnw -q test` *(fails: unable to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c5225eb608330875b86ad5eec797f