### PR TITLE
Add member fines page

### DIFF
--- a/lms-frontend/src/App.jsx
+++ b/lms-frontend/src/App.jsx
@@ -12,6 +12,7 @@ import MemberDashboard from './pages/MemberDashboard'
 import BorrowRecordPage from './pages/BorrowRecordPage'
 import ReservationPage from './pages/ReservationPage'
 import Dashboard from './pages/Dashboard'
+import MyFinesPage from './pages/MyFinesPage'
 import DashboardLayout from './layouts/DashboardLayout'
 import ProtectedRoute from './routes/ProtectedRoute'
 import AdminRoute from './routes/AdminRoute'
@@ -34,7 +35,7 @@ export default function App() {
           <Route path="/dashboard" element={<MemberDashboard />} />
           <Route path="/search-books" element={<SearchBooks />} />
           <Route path="/borrow" element={<BorrowPage />} />
-          <Route path="/my-fines" element={<Dashboard />} />
+          <Route path="/my-fines" element={<MyFinesPage />} />
           <Route
             path="/books"
             element={

--- a/lms-frontend/src/pages/MyFinesPage.jsx
+++ b/lms-frontend/src/pages/MyFinesPage.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import api from '../api/axios'
+import FineIcon from '../assets/icons/FineIcon'
+import Card from '../components/ui/Card'
+
+export default function MyFinesPage() {
+  const [fine, setFine] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchFine = async () => {
+      try {
+        const { data: member } = await api.get('/members/me')
+        const res = await api.get(`/fines/${member.memberId}`)
+        setFine(parseFloat(res.data))
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchFine()
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold flex items-center gap-2">
+        <FineIcon className="w-6 h-6" /> My Fines
+      </h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <Card className="w-fit" role="status" aria-live="polite">
+          <p>
+            Total Outstanding Fines:{' '}
+            <span className="font-semibold">${fine.toFixed(2)}</span>
+          </p>
+        </Card>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `MyFinesPage` to show logged-in member fines
- update the app router to route `/my-fines` to new page

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c531b438c833089c7587ab7b49063