### PR TITLE
Add borrowing history page

### DIFF
--- a/lms-frontend/src/App.jsx
+++ b/lms-frontend/src/App.jsx
@@ -10,6 +10,7 @@ import BorrowPage from './pages/BorrowPage'
 import AdminDashboard from './pages/AdminDashboard'
 import MemberDashboard from './pages/MemberDashboard'
 import BorrowRecordPage from './pages/BorrowRecordPage'
+import BorrowingHistoryPage from './pages/BorrowingHistoryPage'
 import ReservationPage from './pages/ReservationPage'
 import Dashboard from './pages/Dashboard'
 import MyFinesPage from './pages/MyFinesPage'
@@ -61,6 +62,7 @@ export default function App() {
             }
           />
           <Route path="/borrow-records" element={<BorrowRecordPage />} />
+          <Route path="/borrowing-history" element={<BorrowingHistoryPage />} />
           <Route path="/reservations" element={<ReservationPage />} />
         </Route>
       </Routes>

--- a/lms-frontend/src/components/TabNav.jsx
+++ b/lms-frontend/src/components/TabNav.jsx
@@ -34,6 +34,7 @@ export default function TabNav({ role }) {
       label: 'My Borrowed Books',
       icon: BookIcon, // 🧠 Reused BookCard component under My Borrowed Books
     },
+    { to: '/borrowing-history', label: 'Borrowing History', icon: RecordIcon },
     { to: '/reservations', label: 'My Reservations', icon: CalendarIcon },
     { to: '/my-fines', label: 'My Fines', icon: FineIcon },
   ]

--- a/lms-frontend/src/pages/BorrowingHistoryPage.jsx
+++ b/lms-frontend/src/pages/BorrowingHistoryPage.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import api from '../api/axios'
+import RecordIcon from '../assets/icons/RecordIcon'
+import Card from '../components/ui/Card'
+
+export default function BorrowingHistoryPage() {
+  const [records, setRecords] = useState([])
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        const { data } = await api.get('/borrow-records/my')
+        setRecords(data)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchHistory()
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold flex items-center gap-2">
+        <RecordIcon className="w-6 h-6" /> Borrowing History
+      </h1>
+      <ul className="space-y-2">
+        {records.map((r) => (
+          <li key={r.recordId}>
+            <Card className="flex flex-col gap-1">
+              <span>
+                Record {r.recordId} &ndash; Book {r.bookId}
+              </span>
+              <span>Borrowed: {r.borrowDate}</span>
+              <span>Due: {r.dueDate}</span>
+              {r.returnDate && <span>Returned: {r.returnDate}</span>}
+              {r.fine > 0 && (
+                <span className="text-red-600">Fine: ${parseFloat(r.fine).toFixed(2)}</span>
+              )}
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `BorrowingHistoryPage` to show past borrowing records for the member
- register the new page with `/borrowing-history` route
- add a Borrowing History tab for members

## Testing
- `npm run lint` *(in `lms-frontend`)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687c53ff78588330a9808f84876aa26e