### PR TITLE
Public book search and book card links

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/config/SecurityConfig.java
@@ -37,6 +37,10 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/books/search",
+                                "/api/books/available",
+                                "/api/books/*").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/lms-frontend/src/components/BookCard.jsx
+++ b/lms-frontend/src/components/BookCard.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import Card from './ui/Card'
 
 export default function BookCard({ book, children }) {
@@ -10,10 +11,10 @@ export default function BookCard({ book, children }) {
   return (
     <Card className="space-y-1">
       <div className="flex justify-between items-start gap-2">
-        <div>
+        <Link to={`/book/${book.bookId}`} className="flex-1 space-y-0.5 hover:underline">
           <h3 className="font-semibold">{book.title}</h3>
           <p className="text-sm text-gray-600">{book.author}</p>
-        </div>
+        </Link>
         <span className={`text-xs px-2 py-1 rounded ${statusClass}`}>{book.status}</span>
       </div>
       {children}


### PR DESCRIPTION
## Summary
- update security rules so GET `/api/books/*` endpoints can be accessed without auth
- link book cards to the book detail page

## Testing
- `./mvnw test -q` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c5643becc8330ae8b25afc70a3662