### PR TITLE
Improve admin borrow/reserve logs

### DIFF
--- a/lms-frontend/src/App.jsx
+++ b/lms-frontend/src/App.jsx
@@ -12,6 +12,7 @@ import MemberDashboard from './pages/MemberDashboard'
 import BorrowRecordPage from './pages/BorrowRecordPage'
 import BorrowingHistoryPage from './pages/BorrowingHistoryPage'
 import ReservationPage from './pages/ReservationPage'
+import AdminLogsPage from './pages/AdminLogsPage'
 import Dashboard from './pages/Dashboard'
 import MyFinesPage from './pages/MyFinesPage'
 import DashboardLayout from './layouts/DashboardLayout'
@@ -58,6 +59,14 @@ export default function App() {
             element={
               <AdminRoute>
                 <AdminDashboard />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="/admin-logs"
+            element={
+              <AdminRoute>
+                <AdminLogsPage />
               </AdminRoute>
             }
           />

--- a/lms-frontend/src/components/TabNav.jsx
+++ b/lms-frontend/src/components/TabNav.jsx
@@ -24,7 +24,11 @@ export default function TabNav({ role }) {
       label: 'Manage Members',
       icon: UserIcon, // ✅ Only show Manage Members tab for Admin
     },
-    { to: '/borrow-records', label: 'Borrow/Reserve Logs', icon: RecordIcon },
+    {
+      to: '/admin-logs',
+      label: 'Borrow/Reserve Logs',
+      icon: RecordIcon,
+    },
   ]
 
   const memberTabs = [

--- a/lms-frontend/src/pages/AdminLogsPage.jsx
+++ b/lms-frontend/src/pages/AdminLogsPage.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import api from '../api/axios'
+import Card from '../components/ui/Card'
+import Button from '../components/ui/Button'
+import RecordIcon from '../assets/icons/RecordIcon'
+
+export default function AdminLogsPage() {
+  const [view, setView] = useState('borrow')
+  const [records, setRecords] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true)
+      try {
+        if (view === 'borrow') {
+          const { data } = await api.get('/borrow-records')
+          setRecords(data)
+        } else {
+          const { data } = await api.get('/reservations')
+          setRecords(data)
+        }
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [view])
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold flex items-center gap-2">
+        <RecordIcon className="w-6 h-6" /> Borrow/Reserve Logs
+      </h1>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          onClick={() => setView('borrow')}
+          className={`${view === 'borrow' ? 'bg-primary' : 'bg-secondary'} text-sm`}
+        >
+          Borrow Records
+        </Button>
+        <Button
+          type="button"
+          onClick={() => setView('reservation')}
+          className={`${view === 'reservation' ? 'bg-primary' : 'bg-secondary'} text-sm`}
+        >
+          Reservations
+        </Button>
+      </div>
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <ul className="space-y-2">
+          {view === 'borrow' &&
+            records.map((r) => (
+              <li key={r.recordId}>
+                <Card className="flex flex-col gap-1">
+                  <span>
+                    Record {r.recordId} &ndash; Book {r.bookId} &ndash; Member{' '}
+                    {r.memberId}
+                  </span>
+                  <span>Borrowed: {r.borrowDate}</span>
+                  <span>Due: {r.dueDate}</span>
+                  {r.returnDate && <span>Returned: {r.returnDate}</span>}
+                  {r.fine > 0 && (
+                    <span className="text-red-600">
+                      Fine: ${parseFloat(r.fine).toFixed(2)}
+                    </span>
+                  )}
+                </Card>
+              </li>
+            ))}
+          {view === 'reservation' &&
+            records.map((r) => (
+              <li key={r.reservationId}>
+                <Card className="flex justify-between items-center">
+                  <span>
+                    Member {r.memberId} reserved Book {r.bookId} on{' '}
+                    {r.reservationDate}
+                  </span>
+                  <span className="text-xs">{r.status}</span>
+                </Card>
+              </li>
+            ))}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create **AdminLogsPage** for viewing borrow and reservation records
- add route and tab entry for the new admin logs page

## Testing
- `npm run format`
- `./mvnw test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c5a4e240483308d46569606770ecc