### PR TITLE
Improve dashboard readability with member/book names

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
@@ -14,7 +14,9 @@ import java.time.LocalDate;
 public class BorrowRecordDto {
     private Integer recordId;
     private Integer memberId;
+    private String memberName;
     private Integer bookId;
+    private String bookTitle;
     private LocalDate borrowDate;
     private LocalDate dueDate;
     private LocalDate returnDate;
@@ -29,9 +31,11 @@ public class BorrowRecordDto {
         dto.setRecordId(record.getRecordId());
         if (record.getMember() != null) {
             dto.setMemberId(record.getMember().getMemberId());
+            dto.setMemberName(record.getMember().getFullName());
         }
         if (record.getBook() != null) {
             dto.setBookId(record.getBook().getBookId());
+            dto.setBookTitle(record.getBook().getTitle());
         }
         dto.setBorrowDate(record.getBorrowDate());
         dto.setDueDate(record.getDueDate());

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/ReservationDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/ReservationDto.java
@@ -14,7 +14,9 @@ import java.time.LocalDate;
 public class ReservationDto {
     private Integer reservationId;
     private Integer memberId;
+    private String memberName;
     private Integer bookId;
+    private String bookTitle;
     private LocalDate reservationDate;
     private ReservationStatus status;
 
@@ -26,9 +28,11 @@ public class ReservationDto {
         dto.setReservationId(reservation.getReservationId());
         if (reservation.getMember() != null) {
             dto.setMemberId(reservation.getMember().getMemberId());
+            dto.setMemberName(reservation.getMember().getFullName());
         }
         if (reservation.getBook() != null) {
             dto.setBookId(reservation.getBook().getBookId());
+            dto.setBookTitle(reservation.getBook().getTitle());
         }
         dto.setReservationDate(reservation.getReservationDate());
         dto.setStatus(reservation.getStatus());

--- a/lms-frontend/src/pages/AdminDashboard.jsx
+++ b/lms-frontend/src/pages/AdminDashboard.jsx
@@ -43,7 +43,7 @@ export default function AdminDashboard() {
               className={`flex justify-between items-center ${isBlocked(r) ? 'border-red-300 ring-1 ring-red-300' : ''}`}
             >
               <span>
-                Member {r.memberId} &ndash; Book {r.bookId} (due {r.dueDate})
+                Member {r.memberName} (ID {r.memberId}) &ndash; Book {r.bookTitle} (ID {r.bookId}) (due {r.dueDate})
                 {isBlocked(r) && (
                   <span className="text-red-600 text-xs ml-2">Blocked</span>
                 )}

--- a/lms-frontend/src/pages/BorrowRecordPage.jsx
+++ b/lms-frontend/src/pages/BorrowRecordPage.jsx
@@ -136,8 +136,7 @@ export default function BorrowRecordPage() {
               <Card className="flex justify-between items-center gap-2">
                 {/* 🧠 Reused BookCard component under My Borrowed Books */}
                 <span className="flex-1">
-                  Record {r.recordId} &ndash; Book {r.bookId} &ndash; Member{' '}
-                  {r.memberId}
+                  Record {r.recordId} &ndash; Book {r.bookTitle} (ID {r.bookId}) &ndash; Member {r.memberName} (ID {r.memberId})
                   <span className="ml-2">Due: {r.dueDate}</span>
                   {overdue && (
                     <span className="text-red-600 ml-2">Overdue!</span>

--- a/lms-frontend/src/pages/BorrowingHistoryPage.jsx
+++ b/lms-frontend/src/pages/BorrowingHistoryPage.jsx
@@ -28,7 +28,7 @@ export default function BorrowingHistoryPage() {
           <li key={r.recordId}>
             <Card className="flex flex-col gap-1">
               <span>
-                Record {r.recordId} &ndash; Book {r.bookId}
+                Record {r.recordId} &ndash; Book {r.bookTitle} (ID {r.bookId})
               </span>
               <span>Borrowed: {r.borrowDate}</span>
               <span>Due: {r.dueDate}</span>

--- a/lms-frontend/src/pages/ReservationPage.jsx
+++ b/lms-frontend/src/pages/ReservationPage.jsx
@@ -74,7 +74,7 @@ export default function ReservationPage() {
           <li key={r.reservationId}>
             <Card className="flex justify-between items-center gap-2">
               <span>
-                Member {r.memberId} reserved Book {r.bookId} ({r.status})
+                Member {r.memberName} (ID {r.memberId}) reserved Book {r.bookTitle} (ID {r.bookId}) ({r.status})
               </span>
               {r.status === 'ACTIVE' && (
                 <Button


### PR DESCRIPTION
## Summary
- expose `memberName` and `bookTitle` in `BorrowRecordDto`
- expose `memberName` and `bookTitle` in `ReservationDto`
- display member and book names across dashboard pages

## Testing
- `./mvnw test -q` *(fails: Could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c5abcad34833086ee3ba210d6710c