### PR TITLE
Expose borrow and fine stats for members

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/controller/MemberController.java
@@ -32,7 +32,12 @@ public class MemberController {
     public ResponseEntity<List<MemberDto>> getAllMembers() {
         List<MemberDto> list = memberRepository.findAll()
                 .stream()
-                .map(MemberDto::fromEntity)
+                .map(m -> {
+                    MemberDto dto = MemberDto.fromEntity(m);
+                    dto.setBorrowCount(memberRepository.countActiveBorrows(m.getMemberId()));
+                    dto.setFineAmount(memberRepository.sumOutstandingFines(m.getMemberId()));
+                    return dto;
+                })
                 .toList();
         return ResponseEntity.ok(list);
     }
@@ -43,7 +48,12 @@ public class MemberController {
         String n = name != null ? name : "";
         List<MemberDto> list = memberRepository.findByFullNameContainingIgnoreCase(n)
                 .stream()
-                .map(MemberDto::fromEntity)
+                .map(m -> {
+                    MemberDto dto = MemberDto.fromEntity(m);
+                    dto.setBorrowCount(memberRepository.countActiveBorrows(m.getMemberId()));
+                    dto.setFineAmount(memberRepository.sumOutstandingFines(m.getMemberId()));
+                    return dto;
+                })
                 .toList();
         return ResponseEntity.ok(list);
     }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/MemberDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/MemberDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 
@@ -19,6 +20,8 @@ public class MemberDto {
     private LocalDate membershipStart;
     private LocalDate membershipEnd;
     private Integer userId;
+    private long borrowCount;
+    private BigDecimal fineAmount;
 
     public static MemberDto fromEntity(Member member) {
         if (member == null) {
@@ -34,6 +37,8 @@ public class MemberDto {
         if (member.getUser() != null) {
             dto.setUserId(member.getUser().getId());
         }
+        dto.setBorrowCount(0);
+        dto.setFineAmount(BigDecimal.ZERO);
         return dto;
     }
 }

--- a/lms-backend/src/main/java/com/mohammadnizam/lms/repository/MemberRepository.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.mohammadnizam.lms.repository;
 
 import com.mohammadnizam.lms.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,10 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
     List<Member> findByFullNameContainingIgnoreCase(String name);
 
     Optional<Member> findByUser_Username(String username);
+
+    @Query("SELECT COUNT(br) FROM BorrowRecord br WHERE br.member.memberId = :memberId AND br.returnDate IS NULL")
+    long countActiveBorrows(@Param("memberId") Integer memberId);
+
+    @Query("SELECT COALESCE(SUM(br.fine),0) FROM BorrowRecord br WHERE br.member.memberId = :memberId AND br.fine > 0")
+    java.math.BigDecimal sumOutstandingFines(@Param("memberId") Integer memberId);
 }

--- a/lms-frontend/src/pages/MemberListPage.jsx
+++ b/lms-frontend/src/pages/MemberListPage.jsx
@@ -87,7 +87,12 @@ export default function MemberListPage() {
         {members.map((m) => (
           <li key={m.memberId}>
             <Card className="flex justify-between items-start gap-2">
-              <span className="font-medium">{m.fullName}</span>
+              <span className="font-medium">
+                {m.fullName}
+                <span className="block text-sm font-normal">
+                  Borrows: {m.borrowCount} | Fines: ${m.fineAmount}
+                </span>
+              </span>
               <div className="flex gap-2">
                 <Button
                   type="button"


### PR DESCRIPTION
## Summary
- extend `MemberDto` with `borrowCount` and `fineAmount`
- add query methods to `MemberRepository`
- populate borrow and fine data in member listing endpoints
- show borrow and fine counts in `MemberListPage`

## Testing
- `mvn test` *(fails: unable to resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c5e4e0aac8330949533c2ae2fafd9