### PR TITLE
Add days overdue tracking

### DIFF
--- a/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
+++ b/lms-backend/src/main/java/com/mohammadnizam/lms/dto/BorrowRecordDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 @Data
 @NoArgsConstructor
@@ -22,6 +23,7 @@ public class BorrowRecordDto {
     private LocalDate returnDate;
     private BigDecimal fine;
     private Integer renewalCount;
+    private long daysOverdue;
 
     public static BorrowRecordDto fromEntity(BorrowRecord record) {
         if (record == null) {
@@ -42,6 +44,15 @@ public class BorrowRecordDto {
         dto.setReturnDate(record.getReturnDate());
         dto.setRenewalCount(record.getRenewalCount());
         dto.setFine(record.getFine());
+        long overdue = 0;
+        if (record.getDueDate() != null) {
+            LocalDate compareDate = record.getReturnDate() != null ?
+                    record.getReturnDate() : LocalDate.now();
+            if (compareDate.isAfter(record.getDueDate())) {
+                overdue = ChronoUnit.DAYS.between(record.getDueDate(), compareDate);
+            }
+        }
+        dto.setDaysOverdue(overdue);
         return dto;
     }
 }

--- a/lms-frontend/src/pages/AdminDashboard.jsx
+++ b/lms-frontend/src/pages/AdminDashboard.jsx
@@ -43,7 +43,7 @@ export default function AdminDashboard() {
               className={`flex justify-between items-center ${isBlocked(r) ? 'border-red-300 ring-1 ring-red-300' : ''}`}
             >
               <span>
-                Member {r.memberName} (ID {r.memberId}) &ndash; Book {r.bookTitle} (ID {r.bookId}) (due {r.dueDate})
+                Member {r.memberName} (ID {r.memberId}) &ndash; Book {r.bookTitle} (ID {r.bookId}) (due {r.dueDate}, {r.daysOverdue} days overdue)
                 {isBlocked(r) && (
                   <span className="text-red-600 text-xs ml-2">Blocked</span>
                 )}


### PR DESCRIPTION
## Summary
- track how long a borrow record is overdue
- list overdue days in the admin dashboard

## Testing
- `npm run lint` *(in `lms-frontend`)*
- `./mvnw test` *(fails: unable to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c5f1264688330b44fb574a6ac3569