### PR TITLE
Sort borrow records by newest first

### DIFF
--- a/lms-frontend/src/pages/BorrowRecordPage.jsx
+++ b/lms-frontend/src/pages/BorrowRecordPage.jsx
@@ -16,10 +16,15 @@ export default function BorrowRecordPage() {
     endDate: '',
   })
 
+  const sortRecords = (list) =>
+    list.sort(
+      (a, b) => new Date(b.borrowDate) - new Date(a.borrowDate)
+    )
+
   const fetchRecords = async () => {
     try {
       const { data } = await api.get('/borrow-records/my')
-      setRecords(data)
+      setRecords(sortRecords(data))
     } catch (err) {
       console.error(err)
     }
@@ -62,7 +67,7 @@ export default function BorrowRecordPage() {
           endDate: search.endDate,
         },
       })
-      setRecords(data)
+      setRecords(sortRecords(data))
     } catch (err) {
       console.error(err)
     }

--- a/lms-frontend/src/pages/BorrowingHistoryPage.jsx
+++ b/lms-frontend/src/pages/BorrowingHistoryPage.jsx
@@ -5,12 +5,14 @@ import Card from '../components/ui/Card'
 
 export default function BorrowingHistoryPage() {
   const [records, setRecords] = useState([])
+  const sortRecords = (list) =>
+    list.sort((a, b) => new Date(b.borrowDate) - new Date(a.borrowDate))
 
   useEffect(() => {
     const fetchHistory = async () => {
       try {
         const { data } = await api.get('/borrow-records/my')
-        setRecords(data)
+        setRecords(sortRecords(data))
       } catch (err) {
         console.error(err)
       }


### PR DESCRIPTION
## Summary
- show newest borrow records first for a member
- sort search results in the same way
- keep borrowing history in descending order

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687c62f7ede883308ed992ec73eea7af