### PR TITLE
Improve README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Entities include `users`, `books`, `members`, `borrow_transactions` and `reserva
    ```
    Replace this with your own secret (generate with `openssl rand -base64 32`).
    If a registration attempt uses an existing username, the API returns `409 Conflict`.
+   
+   Configure the email server for overdue notifications in the same file:
+   ```properties
+   spring.mail.host=smtp.example.com
+   spring.mail.port=587
+   spring.mail.username=user@example.com
+   spring.mail.password=secret
+   mail.from=library@example.com
+   ```
 
 3. Seed sample data with hashed passwords (required for default logins):
 
@@ -78,11 +87,21 @@ Entities include `users`, `books`, `members`, `borrow_transactions` and `reserva
    npm run dev
    ```
 6. Open `http://localhost:5173` in a browser.
+7. For a production build of the React app:
+   ```bash
+   npm run build
+   npm run preview
+   ```
+
+The backend includes a daily scheduled job that calculates overdue fines and
+sends email reminders to members with outstanding items.
 
 ## API Documentation
 
 A Postman collection covering all API endpoints can be found at
 [docs/LMS.postman_collection.json](docs/LMS.postman_collection.json).
+Interactive Swagger UI documentation is available once the backend is running at
+`http://localhost:8081/swagger-ui.html`.
 
 ## Tests
 Backend unit tests can be executed with:

--- a/lms-backend/README.md
+++ b/lms-backend/README.md
@@ -14,11 +14,13 @@ This module contains the Spring Boot application for the **Library Management Sy
    jwt.secret=BASE64_ENCODED_SECRET
    ```
    You can generate one with `openssl rand -base64 32`.
+   Configure the SMTP settings for email notifications in the same file.
 3. Run the application:
    ```bash
    ./mvnw spring-boot:run
    ```
 4. The API will be available at `http://localhost:8081/api/`.
+   Swagger UI is exposed at `http://localhost:8081/swagger-ui.html`.
 
 ## Common Endpoints
 - `POST /api/auth/register` – user registration
@@ -31,6 +33,10 @@ This module contains the Spring Boot application for the **Library Management Sy
 - `POST /api/return` – return a book
 
 Authentication for protected routes uses JWT tokens in the `Authorization` header.
+
+## Scheduled Tasks
+Overdue fines are recalculated each night at midnight and email reminders are
+sent via the `NotificationService`.
 
 ## Tests
 Run unit tests with:

--- a/lms-frontend/README.md
+++ b/lms-frontend/README.md
@@ -16,7 +16,15 @@ This directory contains the React application for the **Library Management Syste
    npm run dev
    ```
 3. Access the app at `http://localhost:5173`.
+4. Build for production and preview the bundle:
+   ```bash
+   npm run build
+   npm run preview
+   ```
+
+Lint the code with `npm run lint` and format using `npm run format`.
 
 ## About
 The frontend is built with React and Vite. Routing is handled with React Router and API calls use Axios (`src/api/axios.js`) which automatically attaches the JWT token.
 Tailwind CSS provides styling via `tailwind.config.js`.
+The API base URL defaults to `http://localhost:8081/api/` and can be adjusted in `src/api/axios.js`.


### PR DESCRIPTION
## Summary
- document email configuration and scheduled jobs in the main README
- show how to build the React app and link to swagger docs
- mention SMTP and swagger URL in backend README
- document build, lint and base URL settings in frontend README

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687c725c5f248330a9199e8581d9af79